### PR TITLE
Added peer reviewed IT Security Skill Tree

### DIFF
--- a/IT Security Skill Tree/IT Security Skill Tree Peer Review 1.svg
+++ b/IT Security Skill Tree/IT Security Skill Tree Peer Review 1.svg
@@ -1,0 +1,683 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 841.89 1190.55"><json>JTdCJTIydGl0bGUlMjIlM0ElMjJJVCUyMFNFQ1VSSVRZJTIyJTJDJTIyY3JlZGl0cyUyMiUzQSUyMlZpc2l0JTIwdGhlJTIwYSUyMHdlYnNpdGUlMjBvbiUyMFRPUiUyMiUyQyUyMml0ZW1zJTIyJTNBJTdCJTIyMCUyMiUzQSUyMlVuZGVyc3RhbmQlMjBIVFRQUyUyMiUyQyUyMjElMjIlM0ElMjJEbyUyMGElMjBwZXJzb25hbCUyMGRhdGElMjByZXZpZXclMjBhbmQlMjBjbGVhbiUyMiUyQyUyMjIlMjIlM0ElMjJEZWxldGUlMjB5b3VyJTIwdW51c2VkJTIwYWNjb3VudHMlMjIlMkMlMjIzJTIyJTNBJTIyTGVhcm4lMjBhYm91dCUyMGxvY2FsJTIwcHJpdmFjeSUyMGxhd3MlMjIlMkMlMjI0JTIyJTNBJTIyUmUtaW5zdGFsbCUyMGFuJTIwb3BlcmF0aW5nJTIwc3lzdGVtJTIyJTJDJTIyNSUyMiUzQSUyMlVzZSUyMEthbGklMjBMaW51eCUyMiUyQyUyMjYlMjIlM0ElMjJUZWFjaCUyMGElMjBmcmllbmQlMjBhJTIwY3liZXJzZWN1cml0eSUyMHNraWxsJTIyJTJDJTIyNyUyMiUzQSUyMkxpc3RlbiUyMHRvJTIwYSUyMHNlY3VyaXR5JTIwcG9kY2FzdCUyMiUyQyUyMjglMjIlM0ElMjJBdHRlbmQlMjBhJTIwc2VjdXJpdHklMjBjb25mZXJlbmNlJTIyJTJDJTIyOSUyMiUzQSUyMlR1cm4lMjBvbiUyMGxvY2FsJTIwYmFja3VwcyUyMGUuZy4lMjBUaW1lJTIwTWFjaGluZSUyMiUyQyUyMjEwJTIyJTNBJTIyR2V0JTIwYW4lMjBBZGJsb2NrZXIlMjIlMkMlMjIxMSUyMiUzQSUyMlN3aXRjaCUyMHRvJTIwZW5kJTIwdG8lMjBlbmQlMjBlbmNyeXB0ZWQlMjBtZXNzYWdpbmclMjIlMkMlMjIxMiUyMiUzQSUyMkNyZWF0ZSUyMGElMjBzZXBhcmF0ZSUyMFdpRmklMjBuZXR3b3JrJTIwZm9yJTIwZ3Vlc3RzJTIwYW5kJTIwbGlnaHQlMjBidWxicyUyMiUyQyUyMjEzJTIyJTNBJTIyTGVhcm4lMjBhYm91dCUyMGtleWxvZ2dpbmclMjIlMkMlMjIxNCUyMiUzQSUyMkxlYXJuJTIwYWJvdXQlMjBmaXJld2FsbCUyMHNldHRpbmdzJTIyJTJDJTIyMTUlMjIlM0ElMjJFbmNyeXB0JTIweW91ciUyMGRldmljZXMlMjIlMkMlMjIxNiUyMiUzQSUyMkxlYXJuJTIwaG93JTIwdG8lMjB1c2UlMjBTU0glMjIlMkMlMjIxNyUyMiUzQSUyMlVzZSUyMFdpcmVzaGFyayUyMHRvJTIwc2VlJTIwd2hhdCUyMHlvdXIlMjBTbWFydCUyMFRWJTIwaXMlMjB1cCUyMHRvJTIyJTJDJTIyMTglMjIlM0ElMjJQYXJ0aWNpcGF0ZSUyMGluJTIwYSUyMGNhcHR1cmUlMjB0aGUlMjBmbGFnJTIwYWN0aXZpdHklMjIlMkMlMjIxOSUyMiUzQSUyMlVwZGF0ZSUyMHlvdXIlMjByb3V0ZXIlMjBwYXNzd29yZCUyMiUyQyUyMjIwJTIyJTNBJTIyU2lnbiUyMHVwJTIwZm9yJTIwJ0hhdmUlMjBJJTIwYmVlbiUyMHB3bmQlM0YnJTIyJTJDJTIyMjElMjIlM0ElMjJVc2UlMjBhJTIwbWFsd2FyZSUyMHNjYW5uZXIlMjIlMkMlMjIyMiUyMiUzQSUyMkxlYXJuJTIwYWJvdXQlMjBldGhpY2FsJTIwaGFja2luZyUyMiUyQyUyMjIzJTIyJTNBJTIyRGVjaWRlJTIwaWYlMjB5b3UlMjBzaG91bGQlMjBmZWFyJTIwdGhlJTIwZGFyayUyMHdlYiUyMiUyQyUyMjI0JTIyJTNBJTIyVXNlJTIwb3NxdWVyeSUyMHRvJTIwbGlzdCUyMHlvdXIlMjBicm93c2VyJTIwYWRkb25zJTIyJTJDJTIyMjUlMjIlM0ElMjJMZWFybiUyMGFib3V0JTIwWmVybyUyMFRydXN0JTIyJTJDJTIyMjYlMjIlM0ElMjJNYWtlJTIweW91ciUyMG93biUyMEJhZFVTQiUyMiUyQyUyMjI3JTIyJTNBJTIyR2V0JTIwYSUyMHNlY3VyaXR5JTIwY2VydGlmaWNhdGlvbiUyMiUyQyUyMjI4JTIyJTNBJTIyVGVhY2glMjBhJTIwY2xhc3MlMjBvbiUyMGN5YmVyc2VjdXJpdHklMjIlMkMlMjIyOSUyMiUzQSUyMlVwZGF0ZSUyMHlvdXIlMjBvcGVyYXRpbmclMjBzeXN0ZW0lMjIlMkMlMjIzMCUyMiUzQSUyMkJsb2NrJTIwYW5kJTIwcmVwb3J0JTIwYSUyMHNjYW0lMjIlMkMlMjIzMSUyMiUzQSUyMlByb3RlY3QlMjB5b3Vyc2VsZiUyMGZyb20lMjBSRklEJTIwY2xvbmluZyUyMiUyQyUyMjMyJTIyJTNBJTIyTGVhcm4lMjBhYm91dCUyMG1hbHdhcmUlMkMlMjByYW5zb213YXJlJTIwYW5kJTIwcmVjZW50JTIwdGhyZWF0cyUyMiUyQyUyMjMzJTIyJTNBJTIyTGVhcm4lMjBhYm91dCUyMHJlc3BvbnNpYmxlJTIwZGlzY2xvc3VyZSUyMiUyQyUyMjM0JTIyJTNBJTIyUmVhZCUyMGElMjBDVkUlMjB0aGF0J3MlMjBpbiUyMHRoZSUyMG5ld3MlMjIlMkMlMjIzNSUyMiUzQSUyMkV4cGxvcmUlMjB0aGUlMjBraW5kcyUyMG9mJTIwbXVsdGktZmFjdG9yJTIwYXV0aGVudGljYXRpb24lMjIlMkMlMjIzNiUyMiUzQSUyMlNldCUyMHVwJTIwYSUyMFZQTiUyMHRvJTIweW91ciUyMGhvbWUlMjByb3V0ZXIlMjIlMkMlMjIzNyUyMiUzQSUyMlVzZSUyMHBob3RvcmVjJTIwdG8lMjByZWNvdmVyJTIwZGVsZXRlZCUyMGZpbGVzJTIyJTJDJTIyMzglMjIlM0ElMjJQYXJ0aWNpcGF0ZSUyMGluJTIwYSUyMHJlZCUyMHRlYW0lMjB2cy4lMjBibHVlJTIwdGVhbSUyMGFjdGl2aXR5JTIyJTJDJTIyMzklMjIlM0ElMjJNYW5hZ2UlMjB5b3VyJTIwcHJpdmFjeSUyMHNldHRpbmdzJTIwb24lMjBzb2NpYWwlMjBtZWRpYSUyMiUyQyUyMjQwJTIyJTNBJTIyVW5kZXJzdGFuZCUyMHNlY3VyaXR5JTIwcmlza3MlMjBvZiUyMGJsdWV0b290aCUyMiUyQyUyMjQxJTIyJTNBJTIyTGVhcm4lMjBhYm91dCUyMHRoZSUyME9XQVNQJTIwVG9wJTIwVGVuJTIyJTJDJTIyNDIlMjIlM0ElMjJQcmFjdGljZSUyMHNvY2lhbCUyMGVuZ2luZWVyaW5nJTIwd2l0aCUyMGElMjBmcmllbmQlMjIlMkMlMjI0MyUyMiUzQSUyMkxlYXJuJTIwYWJvdXQlMjBsb2NhbCUyMGN5YmVyc2VjdXJpdHklMjBsYXdzJTIyJTJDJTIyNDQlMjIlM0ElMjJMZWFybiUyMGFib3V0JTIwZmVkZXJhdGVkJTIwaWRlbnRpdHklMjB0ZWNobm9sb2dpZXMlMjIlMkMlMjI0NSUyMiUzQSUyMlVuZGVyc3RhbmQlMjB0aGUlMjBpbXBsaWNhdGlvbnMlMjBhbmQlMjByaXNrcyUyMG9mJTIwZGF0YSUyMGxlYWtzJTIyJTJDJTIyNDYlMjIlM0ElMjJVc2UlMjBObWFwJTIwdG8lMjBsb29rJTIwZm9yJTIwaG9sZXMlMjBpbiUyMHlvdXIlMjBmaXJld2FsbCUyMiUyQyUyMjQ3JTIyJTNBJTIyTGVhcm4lMjBhYm91dCUyMGlkZW50aXR5JTIwbWFuYWdlbWVudCUyMiUyQyUyMjQ4JTIyJTNBJTIyQ2xhaW0lMjBhJTIwYnVnJTIwYm91bnR5JTIyJTJDJTIyNDklMjIlM0ElMjJFbmFibGUlMjBhdXRvbWF0aWMlMjB1cGRhdGVzJTIyJTJDJTIyNTAlMjIlM0ElMjJTZXQlMjB1cCUyMDIlMjBmYWN0b3IlMjBhdXRoZW50aWNhdGlvbiUyMG9yJTIwYSUyMHBhc3NrZXklMjIlMkMlMjI1MSUyMiUzQSUyMlZpZXclMjB0aGUlMjBzb3VyY2UlMjBjb2RlJTIwb2YlMjBhJTIwd2Vic2l0ZSUyMiUyQyUyMjUyJTIyJTNBJTIyUmV2aWV3JTIwYW5kJTIwcmVtb3ZlJTIwdW51c2VkJTIwc29mdHdhcmUlMjIlMkMlMjI1MyUyMiUzQSUyMlZpc2l0JTIwdGhlJTIwQkJDJTIwb24lMjBUT1IlMjIlMkMlMjI1NCUyMiUzQSUyMkNyZWF0ZSUyMGElMjBwZXJzb25hbCUyMHRocmVhdCUyMG1vZGVsJTIyJTJDJTIyNTUlMjIlM0ElMjJVbmRlcnN0YW5kJTIwdGhlJTIwbGltaXRhdGlvbnMlMjBvZiUyMGVtYWlsJTIwc2VjdXJpdHklMjB0ZWNobmlxdWVzJTIyJTJDJTIyNTYlMjIlM0ElMjJTZXQlMjB1cCUyMG11bHRpcGxlJTIwYmFja3VwcyUyMGZvciUyMGZpbGVzJTIyJTJDJTIyNTclMjIlM0ElMjJNYWtlJTIwYW4lMjBlbWVyZ2VuY3klMjBtaXRpZ2F0aW9uJTIwcGxhbiUyMiUyQyUyMjU4JTIyJTNBJTIyTGVhcm4lMjBhYm91dCUyME5JU1QlMjBGcmFtZXdvcmtzJTIyJTJDJTIyNTklMjIlM0ElMjJTcG90JTIwYSUyMHNjYW0lMjBlbWFpbCUyMG9yJTIwdGV4dCUyMiUyQyUyMjYwJTIyJTNBJTIyU2V0JTIwdXAlMjBhJTIwcGFzc3dvcmQlMjBtYW5hZ2VyJTIyJTJDJTIyNjElMjIlM0ElMjJSZXBsYWNlJTIweW91ciUyMG91dGRhdGVkJTIwcGFzc3dvcmRzJTIyJTJDJTIyNjIlMjIlM0ElMjJVbmRlcnN0YW5kJTIwYnJvd3NlciUyMGZpbmdlcnByaW50aW5nJTIwYW5kJTIwdXNlciUyMHRyYWNraW5nJTIyJTJDJTIyNjMlMjIlM0ElMjJMb3NlJTIwc2xlZXAlMjBmcm9tJTIweW91ciUyMG5ld2ZvdW5kJTIwa25vd2xlZGdlJTIyJTJDJTIyNjQlMjIlM0ElMjJMZWFybiUyMGFib3V0JTIwUEtJJTJDJTIwWC41MDklMkMlMjBhbmQlMjBSb290LUNBcyUyMiUyQyUyMjY1JTIyJTNBJTIyU2VuZCUyMGElMjBzZWN1cmUlMjBtZXNzYWdlJTIwd2l0aCUyMEdQRyUyMiUyQyUyMjY2JTIyJTNBJTIyU2V0JTIwdXAlMjBhJTIwd2Vic2l0ZSUyMHdpdGglMjBMZXQncyUyMEVuY3J5cHQlMjIlMkMlMjI2NyUyMiUzQSUyMlByb3RlY3QlMjBhJTIwc2VydmVyJTIwZnJvbSUyMGJydXRlJTIwZm9yY2UlMjBhdHRhY2tzLiUyMiU3RCU3RA==</json>
+	<defs>
+		<style>
+			.cls-1, .cls-10, .cls-12, .cls-22, .cls-6 {
+			stroke: #231f20;
+			}
+
+			.cls-1, .cls-10, .cls-12, .cls-14, .cls-2, .cls-22, .cls-6, .cls-7 {
+			stroke-miterlimit: 10;
+			}
+
+			.cls-1 {
+			stroke-width: 0.5px;
+			fill: url(#linear-gradient);
+			}
+
+			.cls-2, .cls-5, .cls-7 {
+			fill: #010101;
+			}
+
+			.cls-2, .cls-7 {
+			stroke: #010101;
+			}
+
+			.cls-2 {
+			stroke-width: 0.98px;
+			}
+
+			.cls-10, .cls-11, .cls-16, .cls-22, .cls-23, .cls-3, .cls-8 {
+			fill: #fff;
+			}
+
+			.cls-13, .cls-15, .cls-28, .cls-4 {
+			fill: #231f20;
+			}
+
+			.cls-12, .cls-14, .cls-6 {
+			fill: none;
+			}
+
+			.cls-7 {
+			stroke-width: 1.41px;
+			}
+
+			.cls-8 {
+			font-size: 16px;
+			}
+
+			.cls-11, .cls-13, .cls-15, .cls-16, .cls-28, .cls-8 {
+			font-family: Uniform-Condensed6;
+			}
+
+			.cls-9 {
+			letter-spacing: 5.59em;
+			}
+
+			.cls-10 {
+			stroke-width: 0.42px;
+			}
+
+			.cls-11, .cls-13, .cls-23 {
+			font-size: 12px;
+			}
+
+			.cls-12 {
+			stroke-width: 1.17px;
+			}
+
+			.cls-14 {
+			stroke: #000;
+			}
+
+			.cls-15 {
+			font-size: 15.91px;
+			}
+
+			.cls-16, .cls-28 {
+			font-size: 10px;
+			}
+
+			.cls-17 {
+			letter-spacing: -0.02em;
+			}
+
+			.cls-18 {
+			letter-spacing: -0.12em;
+			}
+
+			.cls-19 {
+			letter-spacing: -0.01em;
+			}
+
+			.cls-20 {
+			letter-spacing: -0.01em;
+			}
+
+			.cls-21 {
+			letter-spacing: -0.06em;
+			}
+
+			.cls-22 {
+			stroke-width: 1.06px;
+			}
+
+			.cls-23 {
+			font-family: MyriadPro-Regular, Myriad Pro;
+			}
+
+			.cls-24 {
+			letter-spacing: -0.07em;
+			}
+
+			.cls-25 {
+			letter-spacing: 0.01em;
+			}
+
+			.cls-26 {
+			letter-spacing: -0.01em;
+			}
+
+			.cls-27 {
+			letter-spacing: -0.01em;
+			}
+
+			.cls-29 {
+			letter-spacing: -0.01em;
+			}
+		/*Define the fonts*/
+@font-face {
+	font-family: 'Uniform-Condensed6';
+	src: url('https://schme16.github.io/MakerSkillTree-Generator/sys/fonts/uniform_condensed-webfont.woff2') format('woff2'), url('https://schme16.github.io/MakerSkillTree-Generator/sys/fonts/uniform_condensed-webfont.woff') format('woff');
+	font-weight: normal;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: 'Uniform-Condensed6';
+	src: url('https://schme16.github.io/MakerSkillTree-Generator/sys/fonts/uniform_condensed-webfont.woff2') format('woff2'), url('https://schme16.github.io/MakerSkillTree-Generator/sys/fonts/uniform_condensed-webfont.woff') format('woff');
+	font-weight: normal;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: 'Uniform-Condensed6';
+	src: url('https://schme16.github.io/MakerSkillTree-Generator/sys/fonts/uniform_condensed-webfont.woff2') format('woff2'), url('https://schme16.github.io/MakerSkillTree-Generator/sys/fonts/uniform_condensed-webfont.woff') format('woff');
+	font-weight: normal;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: 'Hansief Regular';
+	src: url('https://schme16.github.io/MakerSkillTree-Generator/sys/fonts/hansief-webfont.woff2') format('woff2'), url('https://schme16.github.io/MakerSkillTree-Generator/sys/fonts/hansief-webfont.woff') format('woff');
+	font-weight: normal;
+	font-style: normal;
+}
+
+
+@font-face {
+	font-family: 'Hansief';
+	src: url('https://schme16.github.io/MakerSkillTree-Generator/sys/fonts/hansief-webfont.woff2') format('woff2'), url('https://schme16.github.io/MakerSkillTree-Generator/sys/fonts/hansief-webfont.woff') format('woff');
+	font-weight: normal;
+	font-style: normal;
+}
+
+html, body {
+	background: #fff;
+	color: #808080;
+	font-size: 16px;
+	font-family: 'Open Sans', 'Arial', sans-serif;
+	height: auto;
+	margin: 0;
+	padding: 0;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-ms-box-sizing: border-box;
+	box-sizing: border-box;
+	/* overflow: hidden; */
+}
+
+.skill-tree-wrapper {
+	max-width: 1000px;
+	margin: auto;
+}
+
+.cls-16, .cls-11 {
+	fill: #fff;
+	cursor: pointer;
+	transition: fill 160ms ease-in-out;
+}
+
+.cls-16:hover, .cls-11:hover {
+	fill: #03A9F4;
+}
+
+.left-wrapper, .right-wrapper {
+	shape-outside: polygon(32px 75px, 0.8px 37.9px, 32.0px 0.6px, 34px 0.6px, 2.8px 37.9px, 34.0px 75.3px, 32.0px 75.3px);
+	width: 33px;
+	height: 75px;
+	float: left;
+	opacity: 0;
+}
+
+.right-wrapper {
+	float: right;
+	shape-outside: polygon(1.300px 75.300px, 32.500px 37.900px, 1.300px 0.600px, 3.300px 0.600px, 34.500px 37.900px, 3.300px 75.300px, 1.300px 75.300px);
+	/* position: relative; */
+	/* top: -76px; */
+	width: 26px;
+}
+
+foreignObject {
+	/* fill: red; */
+	/* width: 125px; */
+	/* height: 74px; */
+	outline: none !important;
+}
+
+.textbox-wrapper {
+	width: 117px;
+	height: 74px;
+	/* overflow: hidden; */
+	text-align: center;
+	text-overflow: ellipsis;
+	/* display: flex; */
+	flex-direction: row;
+	flex-wrap: nowrap;
+	align-content: center;
+	justify-content: center;
+	align-items: center;
+	color: #1e1e1e;
+	word-wrap: break-word;
+	max-width: 125px;
+	max-height: 74px;
+	user-select: none;
+	cursor: move;
+}
+
+.textbox-inner {
+	font-size: 10px;
+	margin: 0;
+	padding: 0;
+	/* text-overflow: ellipsis; */
+	font-family: 'Uniform-Condensed6';
+	font-weight: normal;
+	word-break: keep-all;
+	/* hyphens: auto; */
+	height: calc(100% - 5px);
+	width: calc(100% + 9px);
+	white-space: pre-line;
+	margin-top: 3px;
+}
+
+
+.textbox-inner * {
+	text-align: center;
+	word-break: break-all;
+}
+
+
+.textbox-wrapper.draggable-mirror {
+	overflow: hidden;
+	/* background-color: red; */
+	background-image: url('../img/hexagonal.svg');
+	background-size: cover;
+	background-repeat: no-repeat;
+	transform-origin: 19px 1px !important;
+	transform-style: flat;
+	overflow: hidden;
+	height: 87px !important;
+	width: 123px !important;
+	opacity: 0.8;
+}
+
+.draggable-mirror .textbox-inner {
+}
+
+.draggable-mirror .right-wrapper {
+}
+
+.draggable-mirror .left-wrapper {
+}
+
+.textbox-inner-edit-title {
+	font-size: 21px;
+}
+
+.textbox-inner-edit {
+	display: flex;
+	flex-direction: column;
+	flex-wrap: nowrap;
+	align-content: center;
+	justify-content: center;
+	align-items: center;
+	margin: -5px -9px;
+	padding: 10px;
+}
+
+.textbox-inner-edit-text {
+	/* height: 100px; */
+	text-align: center;
+	width: 140px;
+	margin-bottom: 10px;
+	resize: none;
+	overflow: hidden;
+}
+
+text {
+	fill: rgb(30, 30, 30);
+	font-family: 'Uniform-Condensed6';
+	font-weight: normal;
+	font-size: 12px;
+}
+
+tspan {
+	/* x: 50px; */
+}
+
+input {
+	overflow: visible;
+	width: 100%;
+	border: 0;
+	outline: 0;
+	line-height: 1.3;
+}
+
+
+.buttons {
+	position: fixed;
+	top: 20px;
+	right: 20px;
+}
+
+.header,
+.header input,
+.header text,
+.header tspan {
+	fill: #1e1e1e;
+	font-family: Hansief, "Hansief";
+	font-weight: normal;
+	font-size: 69px;
+	text-align: center;
+	margin-left: -2px;
+	display: block;
+}
+
+#description text {
+	font-size: 9.5px;
+}
+
+.credits-edit-text {
+	border: 1px solid #cacaca;
+	padding: 5px 6px;
+	text-transform: uppercase;
+	width: 540px;
+	text-align: center;
+}
+
+text#credits {
+	cursor: pointer;
+	text-transform: uppercase;
+	transition: font-size 250ms ease-in-out;
+}
+
+#credits.font-size-15 {
+	font-size: 15px !important;
+}
+
+#credits.font-size-14 {
+	font-size: 14px !important;
+}
+
+#credits.font-size-13 {
+	font-size: 13px !important;
+}
+
+#credits.font-size-12 {
+	font-size: 12px !important;
+}
+
+#credits.font-size-11 {
+	font-size: 11px !important;
+}
+
+
+.tippy-box {
+	max-width: unset !important;
+	width: fit-content;
+}
+
+[data-tippy-root] {
+	max-width: unset;
+	width: fit-content;
+}</style>
+		<linearGradient id="linear-gradient" x1="43.78" y1="1118.08" x2="43.78" y2="178.03" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#fff"></stop>
+			<stop offset="0.81"></stop>
+		</linearGradient>
+	</defs>
+	<polygon class="cls-1" points="60.15 1094.08 68.56 1094.08 43.83 1118.08 18.4 1094.08 27.31 1094.08 27.31 202.03 19 202.03 43.73 178.03 69.16 202.03 60.15 202.03 60.15 1094.08"></polygon>
+	<g transform="translate(-10,0)">
+		<rect class="cls-2" x="223.82" y="81.17" width="412.8" height="33.19"></rect>
+
+
+		<path class="cls-3" d="M235.38,95.21A3.18,3.18,0,0,1,238.84,92a3.77,3.77,0,0,1,3.67,2.68l-1.15.43a2.76,2.76,0,0,0-2.49-1.9,1.86,1.86,0,0,0-2.09,1.83c0,1.3,1,2.09,2.55,3,1.77,1,3,2.27,3,4.08a3.34,3.34,0,0,1-3.64,3.45,4.23,4.23,0,0,1-4-3.13l1.15-.42s.76,2.34,2.79,2.34A2.07,2.07,0,0,0,241,102.3c0-1.38-.93-2.23-2.61-3.19S235.38,96.77,235.38,95.21Z"></path>
+		<path class="cls-3" d="M246.11,92.23v7.86l4-4.26h1.7l-4.28,4.34,4.47,5.26h-1.72l-4.15-5v5h-1.33V92.23Z"></path>
+		<path class="cls-3" d="M255.05,93.06a1,1,0,1,1-1.92,0,1,1,0,1,1,1.92,0Zm-.26,2.77v9.6h-1.4v-9.6Z"></path>
+		<path class="cls-3" d="M259,92.23v13.2h-1.39V92.23Z"></path>
+		<path class="cls-3" d="M263.24,92.23v13.2h-1.4V92.23Z"></path>
+		<path class="cls-3" d="M274,105.43h-1.42v-12h-3.2V92.23h7.82v1.24H274Z"></path>
+		<path class="cls-3" d="M279,95.83l.1,1.74a3.43,3.43,0,0,1,3.37-1.93V97H282c-1.68,0-2.81,1-2.81,3.42v5.05h-1.34v-9.6Z"></path>
+		<path class="cls-3" d="M287.26,105.62a3.43,3.43,0,0,1-3.66-3.68V99.36a3.5,3.5,0,0,1,3.7-3.72,3.39,3.39,0,0,1,3.6,3.68v1.26h-6v1.3a2.28,2.28,0,0,0,2.34,2.53,2.36,2.36,0,0,0,2.34-2.3l1.26.23A3.52,3.52,0,0,1,287.26,105.62Zm2.36-6v-.32a2.35,2.35,0,1,0-4.68,0v.32Z"></path>
+		<path class="cls-3" d="M296.82,105.62a3.43,3.43,0,0,1-3.66-3.68V99.36a3.5,3.5,0,0,1,3.7-3.72,3.39,3.39,0,0,1,3.6,3.68v1.26h-6v1.3a2.29,2.29,0,0,0,2.34,2.53,2.36,2.36,0,0,0,2.34-2.3l1.26.23A3.52,3.52,0,0,1,296.82,105.62Zm2.36-6v-.32a2.35,2.35,0,1,0-4.68,0v.32Z"></path>
+		<path class="cls-3" d="M304.27,96.6a1,1,0,1,1-1-1A.94.94,0,0,1,304.27,96.6Zm0,8.06a1,1,0,1,1-1-1A.94.94,0,0,1,304.27,104.66Z"></path>
+		<path class="cls-3" d="M322.66,100.87v.58c0,2.6-1.55,4.17-3.93,4.17s-3.94-1.53-3.94-4.13V96.21c0-2.6,1.59-4.17,4-4.17s3.89,1.53,3.89,4.13v.45h-1.34v-.37c0-1.85-.95-3-2.57-3s-2.56,1.1-2.56,3v5.18c0,1.83.94,2.94,2.56,2.94s2.57-1.11,2.57-2.94v-.56Z"></path>
+		<path class="cls-3" d="M328.62,95.64a3.42,3.42,0,0,1,3.65,3.68v2.58a3.5,3.5,0,0,1-3.69,3.72,3.43,3.43,0,0,1-3.66-3.68V99.36A3.5,3.5,0,0,1,328.62,95.64Zm0,8.77a2.29,2.29,0,0,0,2.34-2.53v-2.5a2.35,2.35,0,1,0-4.68,0v2.5A2.28,2.28,0,0,0,328.6,104.41Z"></path>
+		<path class="cls-3" d="M336.21,92.23v13.2h-1.39V92.23Z"></path>
+		<path class="cls-3" d="M342.46,95.64a3.42,3.42,0,0,1,3.66,3.68v2.58a3.51,3.51,0,0,1-3.7,3.72,3.43,3.43,0,0,1-3.66-3.68V99.36A3.5,3.5,0,0,1,342.46,95.64Zm0,8.77a2.29,2.29,0,0,0,2.34-2.53v-2.5a2.35,2.35,0,1,0-4.68,0v2.5A2.28,2.28,0,0,0,342.44,104.41Z"></path>
+		<path class="cls-3" d="M349.73,95.83l.1,1.74a3.44,3.44,0,0,1,3.38-1.93V97h-.5c-1.67,0-2.81,1-2.81,3.42v5.05h-1.33v-9.6Z"></path>
+		<path class="cls-3" d="M360.88,93.06a1,1,0,1,1-1-1A1,1,0,0,1,360.88,93.06Zm-.26,2.77v9.6h-1.4v-9.6Z"></path>
+		<path class="cls-3" d="M364.52,95.83l.07,1.36a3.05,3.05,0,0,1,2.81-1.55c1.87,0,3.12,1.23,3.12,3.72v6.07h-1.34V99.66c0-1.92-.81-2.81-2.17-2.81s-2.32.83-2.32,2.68v5.9h-1.34v-9.6Z"></path>
+		<path class="cls-3" d="M382.28,95.83v1.08h-3v6a1.34,1.34,0,0,0,1.49,1.53,5.45,5.45,0,0,0,1.31-.19l.2,1.12a5.78,5.78,0,0,1-1.9.28,2.3,2.3,0,0,1-2.43-2.55V96.91h-1.61V95.83H378V93.36h1.33v2.47Z"></path>
+		<path class="cls-3" d="M385.41,92.23v4.9a3,3,0,0,1,2.72-1.49c1.87,0,3.11,1.23,3.11,3.72v6.07H389.9V99.66c0-1.92-.81-2.81-2.17-2.81s-2.32.87-2.32,2.77v5.81h-1.34V92.23Z"></path>
+		<path class="cls-3" d="M397.26,105.62a3.43,3.43,0,0,1-3.66-3.68V99.36a3.49,3.49,0,0,1,3.69-3.72,3.39,3.39,0,0,1,3.6,3.68v1.26h-5.95v1.3a2.28,2.28,0,0,0,2.33,2.53,2.36,2.36,0,0,0,2.34-2.3l1.27.23A3.53,3.53,0,0,1,397.26,105.62Zm2.35-6v-.32a2.34,2.34,0,1,0-4.67,0v.32Z"></path>
+		<path class="cls-3" d="M408.91,92.23V97a3,3,0,0,1,2.68-1.36,3.18,3.18,0,0,1,3.34,3.51v2.9a3.26,3.26,0,0,1-3.4,3.57,3,3,0,0,1-2.72-1.42l-.07,1.23h-1.17V92.23Zm2.34,12.18a2.29,2.29,0,0,0,2.34-2.53v-2.5a2.35,2.35,0,1,0-4.68,0v2.5A2.28,2.28,0,0,0,411.25,104.41Z"></path>
+		<path class="cls-3" d="M420.88,95.64a3.42,3.42,0,0,1,3.66,3.68v2.58a3.5,3.5,0,0,1-3.69,3.72,3.43,3.43,0,0,1-3.66-3.68V99.36A3.49,3.49,0,0,1,420.88,95.64Zm0,8.77a2.28,2.28,0,0,0,2.34-2.53v-2.5a2.34,2.34,0,1,0-4.67,0v2.5A2.28,2.28,0,0,0,420.86,104.41Z"></path>
+		<path class="cls-3" d="M433.73,105.43h-1.55l-2.55-3.94-2.58,3.94h-1.47l3.32-4.9-3.13-4.7h1.54l2.36,3.66,2.4-3.66h1.47l-3.13,4.62Z"></path>
+		<path class="cls-3" d="M438.42,105.62a3.43,3.43,0,0,1-3.66-3.68V99.36a3.5,3.5,0,0,1,3.7-3.72,3.39,3.39,0,0,1,3.6,3.68v1.26h-6v1.3a2.28,2.28,0,0,0,2.34,2.53,2.37,2.37,0,0,0,2.34-2.3l1.26.23A3.53,3.53,0,0,1,438.42,105.62Zm2.36-6v-.32a2.35,2.35,0,1,0-4.68,0v.32Z"></path>
+		<path class="cls-3" d="M450,102.87a2.82,2.82,0,0,1-3.13,2.75,4.58,4.58,0,0,1-3.23-1.19l.72-.94a4,4,0,0,0,2.51,1,1.58,1.58,0,0,0,1.79-1.49c0-.74-.38-1.44-2.17-2.08-1.49-.54-2.43-1.49-2.43-2.77s1.11-2.51,2.92-2.51a4,4,0,0,1,2.81,1l-.72.95a2.86,2.86,0,0,0-2-.8c-1.1,0-1.64.64-1.64,1.27s.39,1.32,1.88,1.86C449.13,100.55,450,101.49,450,102.87Z"></path>
+		<path class="cls-3" d="M462.05,105.43l-.15-1a3.26,3.26,0,0,1-2.74,1.23c-2,0-3.32-1.25-3.32-3a3.07,3.07,0,0,1,3.38-3,3.27,3.27,0,0,1,2.55,1V99.51a2.35,2.35,0,0,0-2.47-2.66,4.64,4.64,0,0,0-2.44.6l-.41-1.07a5.34,5.34,0,0,1,3-.74c2.22,0,3.63,1.36,3.63,3.79v6Zm-.19-2.83c0-1.13-1-1.92-2.38-1.92s-2.3.79-2.3,1.92a2.05,2.05,0,0,0,2.3,2C460.92,104.56,461.86,103.73,461.86,102.6Z"></path>
+		<path class="cls-3" d="M466.82,95.83l.07,1.36a3.05,3.05,0,0,1,2.81-1.55c1.87,0,3.12,1.23,3.12,3.72v6.07h-1.34V99.66c0-1.92-.81-2.81-2.17-2.81s-2.32.83-2.32,2.68v5.9h-1.34v-9.6Z"></path>
+		<path class="cls-3" d="M481.34,105.43l-.08-1.28a3,3,0,0,1-2.75,1.47,3.18,3.18,0,0,1-3.34-3.51V99.19a3.25,3.25,0,0,1,3.4-3.55,3,3,0,0,1,2.62,1.3V92.23h1.34v13.2Zm-2.49-8.58a2.28,2.28,0,0,0-2.34,2.53v2.5a2.35,2.35,0,1,0,4.68,0v-2.5A2.28,2.28,0,0,0,478.85,96.85Z"></path>
+		<path class="cls-3" d="M490.88,92.23v13.2h-1.39V92.23Z"></path>
+		<path class="cls-3" d="M497.09,105.62a3.43,3.43,0,0,1-3.66-3.68V99.36a3.49,3.49,0,0,1,3.69-3.72,3.4,3.4,0,0,1,3.61,3.68v1.26h-6v1.3a2.28,2.28,0,0,0,2.33,2.53,2.36,2.36,0,0,0,2.34-2.3l1.27.23A3.53,3.53,0,0,1,497.09,105.62Zm2.35-6v-.32a2.34,2.34,0,1,0-4.67,0v.32Z"></path>
+		<path class="cls-3" d="M503.5,95.83l2.54,7.7,2.53-7.7H510l-3.32,9.6h-1.29L502,95.83Z"></path>
+		<path class="cls-3" d="M514.94,105.62a3.43,3.43,0,0,1-3.66-3.68V99.36a3.5,3.5,0,0,1,3.7-3.72,3.39,3.39,0,0,1,3.6,3.68v1.26h-6v1.3a2.29,2.29,0,0,0,2.34,2.53,2.36,2.36,0,0,0,2.34-2.3l1.26.23A3.52,3.52,0,0,1,514.94,105.62Zm2.36-6v-.32a2.35,2.35,0,1,0-4.68,0v.32Z"></path>
+		<path class="cls-3" d="M522.52,92.23v13.2h-1.39V92.23Z"></path>
+		<path class="cls-3" d="M535.38,105.43l-.07-1.36a3.05,3.05,0,0,1-2.81,1.55c-1.87,0-3.11-1.23-3.11-3.72V95.83h1.34v5.77c0,1.93.81,2.81,2.16,2.81s2.32-.83,2.32-2.68v-5.9h1.34v9.6Z"></path>
+		<path class="cls-3" d="M540.36,95.83l.08,1.26a3.12,3.12,0,0,1,2.77-1.45,3.18,3.18,0,0,1,3.34,3.51v2.9a3.26,3.26,0,0,1-3.4,3.57,3,3,0,0,1-2.62-1.3v4.13h-1.34V95.83Zm2.51,8.58a2.28,2.28,0,0,0,2.34-2.53v-2.5a2.35,2.35,0,1,0-4.68,0v2.5A2.29,2.29,0,0,0,542.87,104.41Z"></path>
+		<path class="cls-3" d="M553.54,95.83l2.55,7.88,2.53-7.88H560l-3.45,10c-.75,2.15-1.77,2.83-3,2.83a2.48,2.48,0,0,1-1.24-.27l.28-1.07a2.17,2.17,0,0,0,.85.15c.85,0,1.49-.44,2-2l-3.32-9.6Z"></path>
+		<path class="cls-3" d="M565,95.64a3.42,3.42,0,0,1,3.66,3.68v2.58a3.51,3.51,0,0,1-3.7,3.72,3.43,3.43,0,0,1-3.66-3.68V99.36A3.5,3.5,0,0,1,565,95.64Zm0,8.77a2.29,2.29,0,0,0,2.34-2.53v-2.5a2.35,2.35,0,1,0-4.68,0v2.5A2.28,2.28,0,0,0,565,104.41Z"></path>
+		<path class="cls-3" d="M577,105.43l-.08-1.36a3,3,0,0,1-2.81,1.55c-1.86,0-3.11-1.23-3.11-3.72V95.83h1.34v5.77c0,1.93.81,2.81,2.17,2.81s2.32-.83,2.32-2.68v-5.9h1.34v9.6Z"></path>
+		<path class="cls-3" d="M582,95.83l.09,1.74a3.44,3.44,0,0,1,3.38-1.93V97H585c-1.68,0-2.81,1-2.81,3.42v5.05h-1.34v-9.6Z"></path>
+		<path class="cls-3" d="M596.91,102.87c0,1.58-1.22,2.75-3.13,2.75a4.56,4.56,0,0,1-3.22-1.19l.72-.94a4,4,0,0,0,2.5,1c1.14,0,1.8-.68,1.8-1.49s-.38-1.44-2.17-2.08c-1.49-.54-2.44-1.49-2.44-2.77s1.12-2.51,2.93-2.51a4,4,0,0,1,2.81,1l-.72.95a2.87,2.87,0,0,0-2-.8c-1.09,0-1.64.64-1.64,1.27s.4,1.32,1.89,1.86C596,100.55,596.91,101.49,596.91,102.87Z"></path>
+		<path class="cls-3" d="M600.23,92.23v7.86l4-4.26h1.7l-4.28,4.34,4.47,5.26h-1.72l-4.15-5v5h-1.34V92.23Z"></path>
+		<path class="cls-3" d="M609.17,93.06a1,1,0,1,1-1.92,0,1,1,0,1,1,1.92,0Zm-.26,2.77v9.6h-1.4v-9.6Z"></path>
+		<path class="cls-3" d="M613.13,92.23v13.2h-1.4V92.23Z"></path>
+		<path class="cls-3" d="M617.35,92.23v13.2H616V92.23Z"></path>
+		<path class="cls-3" d="M625.6,102.87c0,1.58-1.23,2.75-3.14,2.75a4.56,4.56,0,0,1-3.22-1.19l.72-.94a4,4,0,0,0,2.5,1c1.14,0,1.8-.68,1.8-1.49s-.38-1.44-2.17-2.08c-1.49-.54-2.44-1.49-2.44-2.77s1.12-2.51,2.93-2.51a4,4,0,0,1,2.81,1l-.72.95a2.87,2.87,0,0,0-2-.8c-1.09,0-1.64.64-1.64,1.27s.4,1.32,1.89,1.86C624.71,100.55,625.6,101.49,625.6,102.87Z"></path>
+	</g>
+
+
+	<path class="cls-4" d="M34.37,1079.18c0-3.57,2.21-5.94,5.28-5.94a5,5,0,0,1,4.81,3.4,5.44,5.44,0,0,1,5.31-3.85c3.33,0,5.81,2.67,5.81,6.48v6.4H34.37Zm9.31.37a3.76,3.76,0,1,0-7.49,0v3.88h7.49Zm10.09,0a4.21,4.21,0,1,0-8.4,0v3.91h8.4Z"></path>
+	<path class="cls-4" d="M55.58,1058.13,49.65,1060v7.37l5.93,1.85v2.24l-21.21-6.76v-2.18l21.21-6.73Zm-7.66,2.33-10.43,3.21,10.43,3.21Z"></path>
+	<path class="cls-4" d="M39.16,1053.28c-3.06,0-5.09-2.33-5.09-5.55a6.06,6.06,0,0,1,4.3-5.9l.7,1.84s-3.06,1-3.06,4c0,2,1.18,3.37,2.94,3.37,2.09,0,3.36-1.55,4.85-4.09,1.63-2.85,3.63-4.91,6.54-4.91,3.52,0,5.55,2.48,5.55,5.85,0,5.06-5,6.36-5,6.36l-.67-1.85s3.76-1.21,3.76-4.48a3.32,3.32,0,0,0-3.4-3.64c-2.21,0-3.57,1.49-5.12,4.18C43.8,1051.31,41.68,1053.28,39.16,1053.28Z"></path>
+	<path class="cls-4" d="M34.37,1035.44H55.58v2.3H34.37Z"></path>
+	<path class="cls-4" d="M48.25,1018.1h.94c4.18,0,6.7,2.49,6.7,6.31s-2.46,6.33-6.64,6.33H40.77c-4.19,0-6.7-2.55-6.7-6.39s2.45-6.25,6.64-6.25h.72v2.15h-.6c-3,0-4.73,1.52-4.73,4.13s1.76,4.12,4.73,4.12h8.33c2.94,0,4.73-1.52,4.73-4.12s-1.79-4.13-4.73-4.13h-.91Z"></path>
+	<path class="cls-4" d="M39.16,1013.8c-3.06,0-5.09-2.33-5.09-5.54a6.07,6.07,0,0,1,4.3-5.91l.7,1.85s-3.06,1-3.06,4c0,2,1.18,3.36,2.94,3.36,2.09,0,3.36-1.54,4.85-4.09,1.63-2.85,3.63-4.91,6.54-4.91,3.52,0,5.55,2.49,5.55,5.85,0,5.06-5,6.36-5,6.36l-.67-1.85s3.76-1.21,3.76-4.48a3.32,3.32,0,0,0-3.4-3.64c-2.21,0-3.57,1.49-5.12,4.18C43.8,1011.83,41.68,1013.8,39.16,1013.8Z"></path>
+	<path class="cls-3" d="M55.65,332.93l-5.94,1.85v7.36L55.65,344v2.24l-21.21-6.76v-2.18l21.21-6.72ZM48,335.26l-10.42,3.21L48,341.69Z"></path>
+	<path class="cls-3" d="M41.59,315.11h6.82c4.63,0,7.24,2.52,7.24,6.82v5.91H34.44v-6C34.44,317.57,37,315.11,41.59,315.11Zm12.09,6.82c0-3-1.91-4.57-5.21-4.57H41.65c-3.34,0-5.25,1.6-5.25,4.57v3.67H53.68Z"></path>
+	<path class="cls-3" d="M34.44,310.27l17.72-5.43-17.72-5.42v-2.33l21.21,6.72V306l-21.21,6.69Z"></path>
+	<path class="cls-3" d="M55.65,284.39l-5.94,1.85v7.36l5.94,1.85v2.25l-21.21-6.76v-2.18L55.65,282ZM48,286.73l-10.42,3.21L48,293.15Z"></path>
+	<path class="cls-3" d="M55.65,277.24v2.06H34.44v-2.18l16.94-8.76H34.44v-2.09H55.65v2.09L38.5,277.24Z"></path>
+	<path class="cls-3" d="M48.31,249.1h.94c4.19,0,6.7,2.48,6.7,6.3s-2.45,6.33-6.64,6.33H40.83c-4.18,0-6.7-2.54-6.7-6.39s2.46-6.24,6.64-6.24h.73v2.15h-.61c-3,0-4.73,1.51-4.73,4.12s1.76,4.12,4.73,4.12h8.33c2.94,0,4.73-1.52,4.73-4.12s-1.79-4.12-4.73-4.12h-.91Z"></path>
+	<path class="cls-3" d="M34.44,244.55V234h2v8.36h7.28v-7.15h1.85v7.15h8.15v-8.52h2v10.76Z"></path>
+	<path class="cls-3" d="M41.59,217.59h6.82c4.63,0,7.24,2.51,7.24,6.81v5.91H34.44v-6C34.44,220,37,217.59,41.59,217.59Zm12.09,6.81c0-3-1.91-4.57-5.21-4.57H41.65c-3.34,0-5.25,1.6-5.25,4.57v3.67H53.68Z"></path>
+	<path class="cls-4" d="M363,1104.78a3,3,0,0,0,1.6.38,5.75,5.75,0,0,1,3.85,1.3,4.51,4.51,0,0,1,1.63,3.63,4.84,4.84,0,0,1-1.67,3.69,5.66,5.66,0,0,1-8.82-1.57l1.38-.8,1.36-.79a2.54,2.54,0,0,0,2.27,1.47,2.44,2.44,0,0,0,1.57-.56,1.76,1.76,0,0,0,.74-1.44,1.56,1.56,0,0,0-.71-1.39,3,3,0,0,0-1.6-.38,5.74,5.74,0,0,1-3.84-1.3,4.52,4.52,0,0,1-1.63-3.64,4.8,4.8,0,0,1,1.67-3.67,5.64,5.64,0,0,1,8.82,1.57l-2.75,1.58a2.54,2.54,0,0,0-2.27-1.46,2.42,2.42,0,0,0-1.56.55,1.76,1.76,0,0,0-.75,1.43A1.54,1.54,0,0,0,363,1104.78Z"></path>
+	<path class="cls-4" d="M380.13,1098.57v3.16h-3.21v13.18h-3.17v-13.18h-3.22v-3.16Z"></path>
+	<path class="cls-4" d="M386.71,1098.57l4.23,16.34h-3.26l-.64-2.48h-4.42l-.64,2.48h-3.25l4.22-16.34Zm-3.26,10.69h2.76l-1.39-5.33Z"></path>
+	<path class="cls-4" d="M395.36,1108.32v6.59H392.2v-16.34h6a4.9,4.9,0,0,1,4.87,4.88,4.78,4.78,0,0,1-.89,2.8,4.84,4.84,0,0,1-2.33,1.78l2.83,6.88h-3.42l-2.71-6.59Zm0-6.59v3.43h2.86a1.64,1.64,0,0,0,1.2-.5,1.66,1.66,0,0,0,.51-1.21,1.63,1.63,0,0,0-.51-1.21,1.61,1.61,0,0,0-1.2-.51Z"></path>
+	<path class="cls-4" d="M413.51,1098.57v3.16H410.3v13.18h-3.17v-13.18h-3.21v-3.16Z"></path>
+	<path class="cls-4" d="M489.53,1098.57v16.34h-3.16v-6.59h-4.9v6.59h-3.16v-16.34h3.16v6.59h4.9v-6.59Z"></path>
+	<path class="cls-4" d="M500.52,1098.57v3.16h-5.24v3.43h4v3.16h-4v3.43h5.24v3.16h-8.4v-16.34Z"></path>
+	<path class="cls-4" d="M505.64,1108.32v6.59h-3.16v-16.34h6a4.87,4.87,0,0,1,4,7.68,4.8,4.8,0,0,1-2.33,1.78l2.83,6.88h-3.42l-2.71-6.59Zm0-6.59v3.43h2.87a1.63,1.63,0,0,0,1.19-.5,1.67,1.67,0,0,0,.52-1.21,1.64,1.64,0,0,0-.52-1.21,1.6,1.6,0,0,0-1.19-.51Z"></path>
+	<path class="cls-4" d="M523.58,1098.57v3.16h-5.24v3.43h4v3.16h-4v3.43h5.24v3.16h-8.4v-16.34Z"></path>
+	<path class="cls-5" d="M469.27,1118.8l-6-26a1,1,0,0,0-1-.77h-36a1,1,0,0,0-1,.77l-6,26a1,1,0,0,0,1,1.23h48a1,1,0,0,0,1-1.23Zm-24-.77h-2v-3h2Zm0-5h-2v-4h2Zm0-6h-2v-4h2Zm0-6h-2v-4h2Zm0-6h-2v-1h2Z"></path>
+	<path class="cls-4" d="M93.55,1137.87H92.41l-4.68-7.19h0c.07.85.1,1.62.1,2.32v4.87h-.92v-8.57H88l4.67,7.16h0c0-.1,0-.44,0-1s0-1,0-1.23v-4.92h.93Z"></path>
+	<path class="cls-4" d="M99.71,1137.87l-.2-.91h0a2.66,2.66,0,0,1-1,.81,2.81,2.81,0,0,1-1.19.22,2.18,2.18,0,0,1-1.5-.49,1.81,1.81,0,0,1-.54-1.4c0-1.3,1-2,3.11-2l1.09,0v-.4a1.6,1.6,0,0,0-.33-1.11,1.32,1.32,0,0,0-1-.36,4.18,4.18,0,0,0-1.81.49l-.3-.75a4.78,4.78,0,0,1,1-.4,4.39,4.39,0,0,1,1.13-.15,2.42,2.42,0,0,1,1.7.51,2.14,2.14,0,0,1,.56,1.64v4.38Zm-2.2-.68a2,2,0,0,0,1.43-.5,1.87,1.87,0,0,0,.52-1.4v-.58l-1,0a3.6,3.6,0,0,0-1.67.36,1.11,1.11,0,0,0-.51,1,1,1,0,0,0,.32.8A1.34,1.34,0,0,0,97.51,1137.19Z"></path>
+	<path class="cls-4" d="M110.62,1137.87v-4.18a1.73,1.73,0,0,0-.33-1.15,1.29,1.29,0,0,0-1-.38,1.63,1.63,0,0,0-1.34.52,2.47,2.47,0,0,0-.43,1.6v3.59h-1v-4.18a1.73,1.73,0,0,0-.33-1.15,1.28,1.28,0,0,0-1-.38,1.57,1.57,0,0,0-1.34.55,3,3,0,0,0-.42,1.79v3.37h-1v-6.42h.79l.16.88h.05a1.84,1.84,0,0,1,.78-.73,2.29,2.29,0,0,1,1.12-.27,1.91,1.91,0,0,1,2,1.09h0a2.13,2.13,0,0,1,.83-.8,2.68,2.68,0,0,1,1.25-.29,2.19,2.19,0,0,1,1.63.56,2.5,2.5,0,0,1,.54,1.79v4.19Z"></path>
+	<path class="cls-4" d="M116.31,1138a3,3,0,0,1-2.25-.87,3.35,3.35,0,0,1-.82-2.41,3.71,3.71,0,0,1,.76-2.46,2.55,2.55,0,0,1,2.06-.92,2.43,2.43,0,0,1,1.91.8,3.05,3.05,0,0,1,.7,2.09v.62h-4.42a2.49,2.49,0,0,0,.57,1.71,2,2,0,0,0,1.52.59,5.15,5.15,0,0,0,2-.44v.87a4.77,4.77,0,0,1-1,.32A5.13,5.13,0,0,1,116.31,1138Zm-.27-5.84a1.58,1.58,0,0,0-1.23.5,2.28,2.28,0,0,0-.54,1.39h3.36a2.13,2.13,0,0,0-.41-1.4A1.46,1.46,0,0,0,116,1132.15Z"></path>
+	<path class="cls-4" d="M120.19,1132.08c0-.53.23-.8.69-.8s.72.27.72.8a.84.84,0,0,1-.19.58.69.69,0,0,1-.53.21.68.68,0,0,1-.5-.19A.79.79,0,0,1,120.19,1132.08Zm0,5.17a.9.9,0,0,1,.18-.6.65.65,0,0,1,.51-.2.72.72,0,0,1,.53.2.85.85,0,0,1,.19.6.89.89,0,0,1-.19.59.72.72,0,0,1-.53.2.71.71,0,0,1-.5-.18A.83.83,0,0,1,120.19,1137.25Z"></path>
+	<line class="cls-6" x1="126.23" y1="1137.53" x2="337.15" y2="1137.53"></line>
+	<rect class="cls-7" y="1156.36" width="841.89" height="33.19"></rect>
+	<circle class="cls-10" cx="700.43" cy="1152.45" r="25.96"></circle>
+	<path class="cls-4" d="M692.39,1166.54a.35.35,0,0,1-.26-.42,4.54,4.54,0,0,0-.47-2.95.34.34,0,0,1,.08-.37l5-5a.35.35,0,0,1,.49.49l-4.84,4.84a4.85,4.85,0,0,1,.42,3.16A.34.34,0,0,1,692.39,1166.54Z"></path>
+	<path class="cls-4" d="M705.89,1149.14a.34.34,0,0,0-.49,0l-1,1a.35.35,0,1,0,.49.49l1-1A.34.34,0,0,0,705.89,1149.14Z"></path>
+	<path class="cls-4" d="M714.8,1164.2a3,3,0,0,0-.52-.68.35.35,0,0,1,.49-.49,3.34,3.34,0,0,1,.64.83.35.35,0,1,1-.61.34Zm-1.51-1.67-6.92-6.92a3,3,0,0,0-1.35-.77,7,7,0,0,1-2.56-1.23.35.35,0,1,1,.42-.56,6.26,6.26,0,0,0,2.31,1.11,3.58,3.58,0,0,1,1.67.95l6.93,6.93a.36.36,0,0,1,0,.49A.35.35,0,0,1,713.29,1162.53Z"></path>
+	<path class="cls-4" d="M718.39,1146.63a.37.37,0,0,0-.71,0c-.26,1.13-.62,1.25-1.17,1.43a.36.36,0,0,0,0,.69,1.52,1.52,0,0,1,1.17,1.42.36.36,0,0,0,.71,0c.26-1.12.65-1.24,1.18-1.42a.36.36,0,0,0,0-.69C719.06,1147.89,718.66,1147.78,718.39,1146.63ZM718,1149a1.78,1.78,0,0,0-.57-.6,1.68,1.68,0,0,0,.57-.63,1.92,1.92,0,0,0,.54.63A1.88,1.88,0,0,0,718,1149Z"></path>
+	<path class="cls-4" d="M686.47,1158.81a.37.37,0,0,0,.71,0c.26-1.13.65-1.25,1.18-1.43a.36.36,0,0,0,0-.69c-.51-.17-.91-.27-1.18-1.42a.36.36,0,0,0-.71,0c-.26,1.12-.62,1.24-1.17,1.42a.36.36,0,0,0,0,.69C686.21,1157.68,686.32,1158.13,686.47,1158.81Zm.36-2.4a.63.63,0,0,1,0,1.24,1.67,1.67,0,0,0-.56-.6A1.87,1.87,0,0,0,686.83,1156.41Z"></path>
+	<path class="cls-4" d="M701.86,1164.1c-.51-.17-.91-.28-1.17-1.43a.37.37,0,0,0-.71,0c-.26,1.13-.63,1.25-1.18,1.43a.36.36,0,0,0,0,.69c.92.3,1,.75,1.18,1.43a.37.37,0,0,0,.71,0c.26-1.13.64-1.25,1.17-1.43A.36.36,0,0,0,701.86,1164.1Zm-1.52,1a1.92,1.92,0,0,0-.57-.61,1.75,1.75,0,0,0,.56-.63,1.93,1.93,0,0,0,.55.63A1.72,1.72,0,0,0,700.34,1165.06Z"></path>
+	<path class="cls-4" d="M703.51,1135.93c.92.3,1,.75,1.18,1.42a.36.36,0,0,0,.71,0c.26-1.12.64-1.25,1.17-1.42a.36.36,0,0,0,0-.69c-.51-.17-.91-.28-1.17-1.43a.37.37,0,0,0-.71,0c-.26,1.12-.63,1.24-1.18,1.43A.36.36,0,0,0,703.51,1135.93Zm1.53-1a2.06,2.06,0,0,0,.55.63.56.56,0,1,1-1.11,0A1.83,1.83,0,0,0,705,1135Z"></path>
+	<path class="cls-4" d="M703.81,1159.67a.36.36,0,0,0,0,.49l6,6a.36.36,0,0,0,.49,0,.35.35,0,0,0,0-.5l-6-6A.35.35,0,0,0,703.81,1159.67Z"></path>
+	<path class="cls-4" d="M712.76,1163.66a.35.35,0,0,0,0-.5l-6-6a.35.35,0,0,0-.5,0,.36.36,0,0,0,0,.49l6,6A.36.36,0,0,0,712.76,1163.66Z"></path>
+	<path class="cls-4" d="M707.65,1154.08a.35.35,0,1,0,.49,0A.36.36,0,0,0,707.65,1154.08Z"></path>
+	<path class="cls-4" d="M710,1155.9a15.58,15.58,0,0,0,3.54-1.49c1.73-1,2.65-2.26,2.65-3.55s-.83-2.39-2.38-3.39l.3-.11a5.75,5.75,0,0,0,1.88-1.24l.07-.08a.35.35,0,1,0-.5-.48l-.07.06a4.85,4.85,0,0,1-2.54,1.36,15.14,15.14,0,0,0-1.39-.63l-.29-.11a4,4,0,0,0,1.68,0,.35.35,0,0,0,.26-.42.34.34,0,0,0-.42-.26,3.29,3.29,0,0,1-1.53,0,1.51,1.51,0,0,0,0-.7,1.59,1.59,0,0,0-1.55-1.21,1.74,1.74,0,0,0-.39.05,1.42,1.42,0,0,0-.42.22,3.06,3.06,0,0,1-.31,1l0,0,0,.08,0,0,0,.06a.1.1,0,0,0,0,0l0,.06-.07.09v0l-.77-.17,0,0,.07-.08,0,0,0,0,0-.06,0,0,0-.06v0l.05-.06v0l0-.06,0,0,0-.06,0,0,0,0,0-.06v0a.69.69,0,0,1,0-.1h0a2.26,2.26,0,0,0-.54-2.33,2,2,0,0,0-.52-.39,5,5,0,0,1,5.76-4.4.13.13,0,0,1,.06.23l-3.16,3.16a.36.36,0,0,0,0,.49l3.31,3.31a.35.35,0,0,0,.5,0l3.16-3.16a.13.13,0,0,1,.22.07,5.07,5.07,0,0,1-.07,2,.34.34,0,1,0,.67.16,5.48,5.48,0,0,0,.09-2.28.83.83,0,0,0-1.41-.45l-2.91,2.91-2.82-2.81,2.92-2.92a.83.83,0,0,0-.45-1.41,5.66,5.66,0,0,0-6.54,4.86,1.81,1.81,0,0,0-.4,0,2.72,2.72,0,0,0-.49,0,4.25,4.25,0,0,1,.18.7h0c0,.05,0,.09,0,.14v0s0,.08,0,.12v0s0,.1,0,.15,0,.12,0,.19v.09s0,0,0,.08,0,.09,0,.14h0a4.8,4.8,0,0,1-.55,1.78l-.74-.07a4.21,4.21,0,0,0,.63-2h0v-.32a.43.43,0,0,1,0-.05v-.08s0,0,0-.08a.13.13,0,0,0,0-.06.19.19,0,0,0,0-.08V1142a.19.19,0,0,1,0-.08s0,0,0-.06,0-.06,0-.09l0,0,0-.1v0a14.5,14.5,0,0,0-2.42-3.63c-.54-.66-1.1-1.34-1.56-2-.48.7-1,1.39-1.61,2.07a12,12,0,0,0-2.5,3.86v0l0,.11v0s0,.06,0,.09a.17.17,0,0,1,0,.07.2.2,0,0,1,0,.07v.45h0a4.21,4.21,0,0,0,.63,2l-.74.07a4.8,4.8,0,0,1-.55-1.78h0s0-.09,0-.14,0-.05,0-.08v-.09c0-.07,0-.13,0-.19s0-.1,0-.15v0s0-.07,0-.1v-.06l0-.1v0l0-.12v0a3.23,3.23,0,0,1,.14-.51,2.47,2.47,0,0,0-.6-.08,2.25,2.25,0,0,0-2.25,2.25v.11h0a2.4,2.4,0,0,0,.45,1.24h0l.06.07,0,0,.05,0a.27.27,0,0,0,.07.08l.07.06-.78.17a2.93,2.93,0,0,1-.57-1.21.16.16,0,0,0,.08-.06.35.35,0,0,0,0-.49l-2.08-2.08-.45-1.39a.64.64,0,0,0-.08-.14l-3.38-3.38a.37.37,0,0,0-.5,0l-3,3a.34.34,0,0,0,0,.49l3.38,3.38a.42.42,0,0,0,.14.09l1.35.41,2.23,2.24-.33.12c-3,1.18-4.63,2.78-4.63,4.51,0,1.29.92,2.52,2.65,3.55a18.82,18.82,0,0,0,5.91,2.08l-3.44,3.43a5.68,5.68,0,0,0-7.4,6.31.83.83,0,0,0,1.41.45l2.91-2.91,2.82,2.81-2.91,2.91a.84.84,0,0,0,.44,1.42,5.67,5.67,0,0,0,6.3-7.4l5-5a3.06,3.06,0,0,1,.13.43h0a5.22,5.22,0,0,0,1.37,2.43l7.94,7.93a5.26,5.26,0,1,0,7.43-7.44Zm-4.15-10.26c.91.12,1.78.29,2.6.48l-2,2a.35.35,0,0,0,.49.49l2.32-2.32a20.94,20.94,0,0,1,2.07.68l.1,0a4.64,4.64,0,0,1-1.21-.29.36.36,0,0,0-.37.08l-5.31,5.31a4.71,4.71,0,0,1-1.1-.82l-.26-.26a1.85,1.85,0,0,0-.13-2.6Zm-5.92-5.83a10.1,10.1,0,0,0,.61-.81.34.34,0,0,1,.29-.16.36.36,0,0,1,.29.16,7.4,7.4,0,0,0,.59.8,3.29,3.29,0,0,1,1,1.85,1.88,1.88,0,1,1-3.76,0A3.27,3.27,0,0,1,699.89,1139.81Zm.89,5.48a37.41,37.41,0,0,1,4.16.23l-2.57,2.57a1.87,1.87,0,0,0-1.92.43l-1.41,1.42-4.16-4.17A35.69,35.69,0,0,1,700.78,1145.29Zm-6.66.62a.3.3,0,0,0,.1.19l4.33,4.33-1.49,1.49-5.4-5.4C692.43,1146.29,693.26,1146.08,694.12,1145.91Zm-3.88-1.09a2,2,0,0,0,0,.24l-1.63-1.62a.31.31,0,0,0-.14-.09l-1.35-.42-3.07-3.07,2.48-2.48,3.07,3.07.45,1.39a.34.34,0,0,0,.09.14l1.63,1.64A1.59,1.59,0,0,0,690.24,1144.82Zm-1.84,9c-1-.63-2.3-1.65-2.3-3s1.52-2.81,4.19-3.86l.63-.23,5.64,5.64-1.41,1.42a1.83,1.83,0,0,0-.5,1.66,1.93,1.93,0,0,0-.19.38A19,19,0,0,1,688.4,1153.81Zm9.27,5.14-4.22,4.22a.38.38,0,0,0-.08.37,5,5,0,0,1-5.45,6.68.14.14,0,0,1-.07-.23l3.16-3.16a.35.35,0,0,0,0-.5L687.7,1163a.36.36,0,0,0-.49,0l-3.16,3.16a.13.13,0,0,1-.23-.06,5,5,0,0,1,6.68-5.46.38.38,0,0,0,.37-.08l3.44-3.44.78-.78a1.84,1.84,0,0,0,2.6.13,5.7,5.7,0,0,1,1.08,1.37Zm13.74,11.14a4.49,4.49,0,0,1-2.4-1.26l-7.93-7.93a4.61,4.61,0,0,1-1.2-2.1h0a5.19,5.19,0,0,0-.82-1.8,7.78,7.78,0,0,0-.88-1l.51-.51,3.93-3.93.26.26a6.06,6.06,0,0,0,1.11.85c1.12.66,1.64.49,2.64,1.08a.35.35,0,1,0,.35-.6,7.48,7.48,0,0,0-1.81-.7l5-5a5.61,5.61,0,0,0,2.67.23c1.71.93,2.66,2,2.66,3.15,0,1.3-1.25,2.32-2.3,3a16,16,0,0,1-3.76,1.53l-.27-.27a.37.37,0,0,0-.5,0,.35.35,0,0,0,0,.48h0l.56.56,6.27,6.27a4.49,4.49,0,0,1,1.26,2.39A8,8,0,0,0,711.41,1170.09Z"></path>
+	<path class="cls-4" d="M716.77,1144.37a.37.37,0,0,0-.48.14.35.35,0,0,0,.61.34A.36.36,0,0,0,716.77,1144.37Z"></path>
+	<path class="cls-4" d="M702.66,1141.65a1.88,1.88,0,1,1-3.76,0,3.27,3.27,0,0,1,1-1.84,10.1,10.1,0,0,0,.61-.81.34.34,0,0,1,.29-.16.36.36,0,0,1,.29.16,7.4,7.4,0,0,0,.59.8A3.29,3.29,0,0,1,702.66,1141.65Z"></path>
+	<path class="cls-3" d="M701.67,1139.8a7.4,7.4,0,0,1-.59-.8.36.36,0,0,0-.29-.16.34.34,0,0,0-.29.16,10.1,10.1,0,0,1-.61.81,3.27,3.27,0,0,0-1,1.84,1.88,1.88,0,1,0,3.76,0A3.29,3.29,0,0,0,701.67,1139.8Zm-.89,3a1.2,1.2,0,0,1-1.2-1.2c0-.4.42-.91.83-1.41.13-.15.26-.3.38-.46l.35.45c.41.5.84,1,.84,1.42A1.2,1.2,0,0,1,700.78,1142.85Z"></path>
+	<path class="cls-4" d="M702,1141.65a1.2,1.2,0,1,1-2.4,0c0-.4.42-.91.83-1.41.13-.15.26-.3.38-.46l.35.45C701.55,1140.73,702,1141.25,702,1141.65Z"></path>
+	<text class="cls-11" transform="translate(734.21 1176.26)">Icons by Icons8.com</text>
+	<path class="cls-4" d="M102.73,210.58a4.13,4.13,0,0,1,1.85-3.61l.3.37a4.06,4.06,0,0,0,0,6.46l-.3.36A4,4,0,0,1,102.73,210.58Z"></path>
+	<path class="cls-4" d="M108.05,212.28a1.2,1.2,0,0,1-1.32,1.17,1.93,1.93,0,0,1-1.37-.51l.3-.4a1.71,1.71,0,0,0,1.07.43.67.67,0,0,0,.76-.64c0-.31-.16-.6-.92-.88s-1-.63-1-1.17a1.11,1.11,0,0,1,1.24-1.06,1.69,1.69,0,0,1,1.19.41l-.3.4a1.23,1.23,0,0,0-.85-.33c-.47,0-.7.27-.7.53s.17.56.8.79S108.05,211.69,108.05,212.28Z"></path>
+	<path class="cls-4" d="M110.36,213.45a1.46,1.46,0,0,1-1.55-1.56v-1.1a1.48,1.48,0,0,1,1.57-1.57,1.43,1.43,0,0,1,1.53,1.55v.54h-2.53v.55a1,1,0,0,0,1,1.07,1,1,0,0,0,1-1l.54.09A1.51,1.51,0,0,1,110.36,213.45Zm1-2.56v-.13a1,1,0,1,0-2,0v.13Z"></path>
+	<path class="cls-4" d="M115,209.3v.45h-1.27v2.54a.56.56,0,0,0,.63.64,2.31,2.31,0,0,0,.55-.08l.09.48a2.44,2.44,0,0,1-.81.12,1,1,0,0,1-1-1.08v-2.62h-.68v-.45h.68v-1.05h.57v1.05Z"></path>
+	<path class="cls-4" d="M117.68,209.3l1.08,3.34,1.07-3.34h.59L119,213.53c-.32.91-.75,1.19-1.29,1.19a1.13,1.13,0,0,1-.53-.11l.12-.45a1,1,0,0,0,.36.06c.36,0,.63-.18.85-.85l-1.41-4.07Z"></path>
+	<path class="cls-4" d="M122.55,209.22a1.44,1.44,0,0,1,1.55,1.55v1.1a1.49,1.49,0,0,1-1.57,1.58,1.46,1.46,0,0,1-1.55-1.56v-1.1A1.48,1.48,0,0,1,122.55,209.22Zm0,3.71a1,1,0,0,0,1-1.07V210.8a1,1,0,1,0-2,0v1.06A1,1,0,0,0,122.54,212.93Z"></path>
+	<path class="cls-4" d="M127.64,213.37l0-.58a1.29,1.29,0,0,1-1.19.66c-.79,0-1.32-.52-1.32-1.58V209.3h.57v2.44c0,.82.34,1.19.92,1.19s1-.35,1-1.13v-2.5h.57v4.07Z"></path>
+	<path class="cls-4" d="M129.76,209.3l0,.73a1.46,1.46,0,0,1,1.43-.81v.56H131c-.71,0-1.19.43-1.19,1.44v2.15h-.57V209.3Z"></path>
+	<path class="cls-4" d="M135.23,209.22a1.44,1.44,0,0,1,1.55,1.55v1.1a1.49,1.49,0,0,1-1.57,1.58,1.46,1.46,0,0,1-1.55-1.56v-1.1A1.48,1.48,0,0,1,135.23,209.22Zm0,3.71a1,1,0,0,0,1-1.07V210.8a1,1,0,1,0-2,0v1.06A1,1,0,0,0,135.22,212.93Z"></path>
+	<path class="cls-4" d="M138,209.3l.88,3.16.82-3.16H140l.82,3.17.89-3.17h.59l-1.23,4.07h-.5l-.77-2.92-.77,2.92h-.51l-1.22-4.07Z"></path>
+	<path class="cls-4" d="M143.48,209.3l0,.57a1.29,1.29,0,0,1,1.19-.65c.79,0,1.32.52,1.32,1.57v2.58h-.57v-2.45c0-.82-.34-1.19-.92-1.19s-1,.35-1,1.13v2.51H143V209.3Z"></path>
+	<path class="cls-4" d="M150.2,214.21a1.06,1.06,0,0,0,1.16-1.2v-.48a1.3,1.3,0,0,1-1.13.58,1.36,1.36,0,0,1-1.42-1.5v-.89a1.38,1.38,0,0,1,1.44-1.5,1.28,1.28,0,0,1,1.15.6l0-.52h.5V213a1.58,1.58,0,0,1-1.7,1.74,2.71,2.71,0,0,1-1.32-.28l.19-.47A2.44,2.44,0,0,0,150.2,214.21Zm.17-4.48a1,1,0,0,0-1,1.07v.74a1,1,0,1,0,2,0v-.74A1,1,0,0,0,150.37,209.73Z"></path>
+	<path class="cls-4" d="M154.54,209.22a1.44,1.44,0,0,1,1.55,1.55v1.1a1.48,1.48,0,0,1-1.56,1.58,1.46,1.46,0,0,1-1.56-1.56v-1.1A1.48,1.48,0,0,1,154.54,209.22Zm0,3.71a1,1,0,0,0,1-1.07V210.8a1,1,0,1,0-2,0v1.06A1,1,0,0,0,154.53,212.93Z"></path>
+	<path class="cls-4" d="M159.6,213.37l-.06-.44a1.41,1.41,0,0,1-1.16.52,1.27,1.27,0,0,1-1.41-1.26,1.3,1.3,0,0,1,1.43-1.27,1.37,1.37,0,0,1,1.08.43v-.5a1,1,0,0,0-1-1.12,2,2,0,0,0-1,.25l-.17-.45a2.27,2.27,0,0,1,1.28-.31,1.44,1.44,0,0,1,1.54,1.6v2.55Zm-.08-1.2c0-.48-.4-.82-1-.82s-1,.34-1,.82a.87.87,0,0,0,1,.83A.89.89,0,0,0,159.52,212.17Z"></path>
+	<path class="cls-4" d="M161.77,207.77v5.6h-.6v-5.6Z"></path>
+	<path class="cls-4" d="M164.8,210.55a4.13,4.13,0,0,1-1.86,3.61l-.29-.37a4.07,4.07,0,0,0,0-6.45l.29-.37A4,4,0,0,1,164.8,210.55Z"></path>
+	<path class="cls-4" d="M208.43,169a4.13,4.13,0,0,1,1.85-3.61l.3.38a4.05,4.05,0,0,0,0,6.45l-.3.37A4.06,4.06,0,0,1,208.43,169Z"></path>
+	<path class="cls-4" d="M213.75,170.71a1.2,1.2,0,0,1-1.33,1.17,1.92,1.92,0,0,1-1.36-.51l.3-.4a1.7,1.7,0,0,0,1.06.43.67.67,0,0,0,.76-.64c0-.31-.16-.6-.92-.88s-1-.63-1-1.17a1.11,1.11,0,0,1,1.24-1.06,1.69,1.69,0,0,1,1.19.41l-.3.4a1.24,1.24,0,0,0-.86-.33c-.46,0-.69.27-.69.53s.17.56.8.79S213.75,170.12,213.75,170.71Z"></path>
+	<path class="cls-4" d="M216.06,171.88a1.46,1.46,0,0,1-1.55-1.56v-1.1a1.48,1.48,0,0,1,1.57-1.57,1.43,1.43,0,0,1,1.53,1.55v.54h-2.53v.55a1,1,0,0,0,1,1.07,1,1,0,0,0,1-1l.54.09A1.51,1.51,0,0,1,216.06,171.88Zm1-2.55v-.14a1,1,0,1,0-2,0v.14Z"></path>
+	<path class="cls-4" d="M220.69,167.73v.45h-1.27v2.54a.56.56,0,0,0,.63.64,2.31,2.31,0,0,0,.55-.08l.09.48a2.44,2.44,0,0,1-.81.12,1,1,0,0,1-1-1.08v-2.62h-.68v-.45h.68v-1h.57v1Z"></path>
+	<path class="cls-4" d="M223.38,167.73l1.08,3.34,1.07-3.34h.59L224.66,172c-.32.91-.76,1.2-1.29,1.2a1.06,1.06,0,0,1-.53-.12l.12-.45a1,1,0,0,0,.36.06c.36,0,.63-.18.85-.85l-1.41-4.07Z"></path>
+	<path class="cls-4" d="M228.25,167.65a1.44,1.44,0,0,1,1.55,1.55v1.1a1.49,1.49,0,0,1-1.57,1.58,1.46,1.46,0,0,1-1.55-1.56v-1.1A1.48,1.48,0,0,1,228.25,167.65Zm0,3.71a1,1,0,0,0,1-1.07v-1.06a1,1,0,1,0-2,0v1.06A1,1,0,0,0,228.24,171.36Z"></path>
+	<path class="cls-4" d="M233.34,171.8l0-.58a1.29,1.29,0,0,1-1.19.66c-.79,0-1.32-.52-1.32-1.58v-2.57h.57v2.44c0,.82.34,1.19.92,1.19s1-.35,1-1.13v-2.5h.57v4.07Z"></path>
+	<path class="cls-4" d="M235.46,167.73l0,.73a1.45,1.45,0,0,1,1.43-.81v.56h-.21c-.71,0-1.19.44-1.19,1.44v2.15H235v-4.07Z"></path>
+	<path class="cls-4" d="M240.93,167.65a1.44,1.44,0,0,1,1.55,1.55v1.1a1.49,1.49,0,0,1-1.57,1.58,1.46,1.46,0,0,1-1.55-1.56v-1.1A1.48,1.48,0,0,1,240.93,167.65Zm0,3.71a1,1,0,0,0,1-1.07v-1.06a1,1,0,1,0-2,0v1.06A1,1,0,0,0,240.92,171.36Z"></path>
+	<path class="cls-4" d="M243.66,167.73l.88,3.16.82-3.16h.38l.82,3.17.89-3.17H248l-1.23,4.07h-.5l-.78-2.91-.76,2.91h-.51L243,167.73Z"></path>
+	<path class="cls-4" d="M249.18,167.73l0,.57a1.29,1.29,0,0,1,1.19-.65c.79,0,1.32.52,1.32,1.57v2.58h-.57v-2.45c0-.82-.34-1.19-.92-1.19s-1,.35-1,1.13v2.51h-.57v-4.07Z"></path>
+	<path class="cls-4" d="M255.9,172.64a1.06,1.06,0,0,0,1.16-1.2V171a1.3,1.3,0,0,1-1.13.58,1.36,1.36,0,0,1-1.42-1.5v-.89a1.38,1.38,0,0,1,1.44-1.5,1.28,1.28,0,0,1,1.15.6l0-.52h.5v3.68a1.58,1.58,0,0,1-1.7,1.75,2.64,2.64,0,0,1-1.32-.29l.19-.47A2.44,2.44,0,0,0,255.9,172.64Zm.17-4.48a1,1,0,0,0-1,1.07V170a1,1,0,1,0,2,0v-.74A1,1,0,0,0,256.07,168.16Z"></path>
+	<path class="cls-4" d="M260.24,167.65a1.44,1.44,0,0,1,1.55,1.55v1.1a1.48,1.48,0,0,1-1.57,1.58,1.46,1.46,0,0,1-1.55-1.56v-1.1A1.48,1.48,0,0,1,260.24,167.65Zm0,3.71a1,1,0,0,0,1-1.07v-1.06a1,1,0,1,0-2,0v1.06A1,1,0,0,0,260.23,171.36Z"></path>
+	<path class="cls-4" d="M265.3,171.8l-.06-.44a1.38,1.38,0,0,1-1.16.52,1.27,1.27,0,0,1-1.41-1.26,1.3,1.3,0,0,1,1.43-1.27,1.37,1.37,0,0,1,1.08.43v-.49a1,1,0,0,0-1-1.13,2,2,0,0,0-1,.25l-.17-.45a2.27,2.27,0,0,1,1.28-.31,1.44,1.44,0,0,1,1.54,1.6v2.55Zm-.08-1.2c0-.48-.4-.82-1-.82s-1,.34-1,.82a.87.87,0,0,0,1,.83A.89.89,0,0,0,265.22,170.6Z"></path>
+	<path class="cls-4" d="M267.46,166.2v5.6h-.59v-5.6Z"></path>
+	<path class="cls-4" d="M270.5,169a4.16,4.16,0,0,1-1.86,3.62l-.29-.38a4.07,4.07,0,0,0,0-6.45l.29-.37A4,4,0,0,1,270.5,169Z"></path>
+	<path class="cls-4" d="M723,212a4.14,4.14,0,0,1,1.86-3.62l.29.38a4.05,4.05,0,0,0,0,6.45l-.29.37A4,4,0,0,1,723,212Z"></path>
+	<path class="cls-4" d="M728.35,213.67a1.2,1.2,0,0,1-1.33,1.17,2,2,0,0,1-1.37-.5l.31-.4a1.72,1.72,0,0,0,1.06.42.67.67,0,0,0,.76-.63c0-.31-.16-.61-.92-.88s-1-.63-1-1.18a1.11,1.11,0,0,1,1.24-1.06,1.67,1.67,0,0,1,1.19.42l-.3.4a1.22,1.22,0,0,0-.86-.34c-.46,0-.69.27-.69.54s.16.56.8.79S728.35,213.09,728.35,213.67Z"></path>
+	<path class="cls-4" d="M730.66,214.84a1.45,1.45,0,0,1-1.55-1.56v-1.09a1.48,1.48,0,0,1,1.57-1.58,1.43,1.43,0,0,1,1.52,1.56v.54h-2.52v.55a1,1,0,0,0,1,1.07,1,1,0,0,0,1-1l.54.1A1.5,1.5,0,0,1,730.66,214.84Zm1-2.55v-.14a1,1,0,1,0-2,0v.14Z"></path>
+	<path class="cls-4" d="M735.29,210.69v.46H734v2.53a.57.57,0,0,0,.64.65,2.31,2.31,0,0,0,.55-.08l.09.47a2.52,2.52,0,0,1-.81.12,1,1,0,0,1-1-1.08v-2.61h-.68v-.46h.68v-1.05H734v1.05Z"></path>
+	<path class="cls-4" d="M738,210.69l1.08,3.34,1.08-3.34h.59l-1.47,4.23c-.32.91-.75,1.2-1.28,1.2a1.08,1.08,0,0,1-.53-.11l.12-.46a.82.82,0,0,0,.36.07c.36,0,.63-.19.85-.86l-1.41-4.07Z"></path>
+	<path class="cls-4" d="M742.85,210.61a1.45,1.45,0,0,1,1.55,1.56v1.1a1.49,1.49,0,0,1-1.57,1.57,1.45,1.45,0,0,1-1.55-1.56v-1.09A1.48,1.48,0,0,1,742.85,210.61Zm0,3.72a1,1,0,0,0,1-1.07v-1.07a1,1,0,1,0-2,0v1.07A1,1,0,0,0,742.84,214.33Z"></path>
+	<path class="cls-4" d="M747.94,214.76l0-.58a1.29,1.29,0,0,1-1.19.66c-.79,0-1.32-.52-1.32-1.57v-2.58H746v2.45c0,.81.34,1.19.92,1.19s1-.35,1-1.14v-2.5h.57v4.07Z"></path>
+	<path class="cls-4" d="M750.05,210.69l0,.74a1.46,1.46,0,0,1,1.44-.82v.56h-.21c-.71,0-1.19.44-1.19,1.45v2.14h-.57v-4.07Z"></path>
+	<path class="cls-4" d="M755.53,210.61a1.46,1.46,0,0,1,1.55,1.56v1.1a1.49,1.49,0,0,1-1.57,1.57,1.45,1.45,0,0,1-1.55-1.56v-1.09A1.48,1.48,0,0,1,755.53,210.61Zm0,3.72a1,1,0,0,0,1-1.07v-1.07a1,1,0,1,0-2,0v1.07A1,1,0,0,0,755.52,214.33Z"></path>
+	<path class="cls-4" d="M758.25,210.69l.89,3.17.82-3.17h.38l.82,3.17.88-3.17h.6l-1.23,4.07h-.5l-.78-2.91-.77,2.91h-.51l-1.21-4.07Z"></path>
+	<path class="cls-4" d="M763.77,210.69l0,.58a1.28,1.28,0,0,1,1.19-.66c.79,0,1.32.52,1.32,1.58v2.57h-.57v-2.45c0-.81-.35-1.19-.92-1.19s-1,.35-1,1.14v2.5h-.57v-4.07Z"></path>
+	<path class="cls-4" d="M770.49,215.61a1.07,1.07,0,0,0,1.17-1.21v-.47a1.31,1.31,0,0,1-1.13.57,1.35,1.35,0,0,1-1.42-1.49v-.9a1.38,1.38,0,0,1,1.44-1.5,1.28,1.28,0,0,1,1.14.6l0-.52h.5v3.69a1.58,1.58,0,0,1-1.7,1.74,2.71,2.71,0,0,1-1.32-.28l.19-.47A2.42,2.42,0,0,0,770.49,215.61Zm.18-4.49a1,1,0,0,0-1,1.07v.75a1,1,0,1,0,2,0v-.75A1,1,0,0,0,770.67,211.12Z"></path>
+	<path class="cls-4" d="M774.84,210.61a1.45,1.45,0,0,1,1.55,1.56v1.1a1.49,1.49,0,0,1-1.57,1.57,1.45,1.45,0,0,1-1.55-1.56v-1.09A1.48,1.48,0,0,1,774.84,210.61Zm0,3.72a1,1,0,0,0,1-1.07v-1.07a1,1,0,1,0-2,0v1.07A1,1,0,0,0,774.83,214.33Z"></path>
+	<path class="cls-4" d="M779.9,214.76l-.06-.44a1.38,1.38,0,0,1-1.16.52,1.27,1.27,0,0,1-1.41-1.26,1.3,1.3,0,0,1,1.43-1.27,1.35,1.35,0,0,1,1.08.44v-.5a1,1,0,0,0-1-1.13,1.94,1.94,0,0,0-1,.26l-.17-.46a2.27,2.27,0,0,1,1.28-.31,1.45,1.45,0,0,1,1.54,1.61v2.54Zm-.08-1.2c0-.48-.41-.81-1-.81s-1,.33-1,.81a.86.86,0,0,0,1,.83C779.42,214.39,779.82,214,779.82,213.56Z"></path>
+	<path class="cls-4" d="M782.06,209.16v5.6h-.59v-5.6Z"></path>
+	<path class="cls-4" d="M785.09,212a4.13,4.13,0,0,1-1.85,3.61l-.3-.38a4.05,4.05,0,0,0,0-6.45l.3-.37A4,4,0,0,1,785.09,212Z"></path>
+	<path class="cls-4" d="M415.31,169.49a4.13,4.13,0,0,1,1.86-3.61l.29.37a4.08,4.08,0,0,0,0,6.46l-.29.36A4,4,0,0,1,415.31,169.49Z"></path>
+	<path class="cls-4" d="M420.64,171.19a1.19,1.19,0,0,1-1.33,1.16,1.94,1.94,0,0,1-1.36-.5l.3-.4a1.72,1.72,0,0,0,1.06.42c.48,0,.76-.28.76-.63s-.16-.6-.92-.88-1-.63-1-1.17a1.11,1.11,0,0,1,1.24-1.07,1.67,1.67,0,0,1,1.19.42l-.3.4a1.22,1.22,0,0,0-.86-.34c-.46,0-.69.28-.69.54s.17.56.8.79S420.64,170.6,420.64,171.19Z"></path>
+	<path class="cls-4" d="M423,172.35a1.45,1.45,0,0,1-1.55-1.56V169.7a1.48,1.48,0,0,1,1.57-1.58,1.44,1.44,0,0,1,1.53,1.56v.54H422v.55a1,1,0,0,0,1,1.07,1,1,0,0,0,1-1l.54.09A1.5,1.5,0,0,1,423,172.35Zm1-2.55v-.13a1,1,0,1,0-2,0v.13Z"></path>
+	<path class="cls-4" d="M427.58,168.2v.46h-1.27v2.54a.56.56,0,0,0,.63.64,2.31,2.31,0,0,0,.55-.08l.09.47a2.44,2.44,0,0,1-.81.12,1,1,0,0,1-1-1.07v-2.62h-.68v-.46h.68v-1h.57v1Z"></path>
+	<path class="cls-4" d="M430.27,168.2l1.08,3.35,1.07-3.35H433l-1.46,4.23c-.32.92-.76,1.2-1.29,1.2a1.08,1.08,0,0,1-.53-.11l.12-.45a1,1,0,0,0,.36.06c.36,0,.63-.18.85-.86l-1.41-4.07Z"></path>
+	<path class="cls-4" d="M435.14,168.12a1.45,1.45,0,0,1,1.55,1.56v1.1a1.49,1.49,0,0,1-1.57,1.57,1.45,1.45,0,0,1-1.55-1.56V169.7A1.48,1.48,0,0,1,435.14,168.12Zm0,3.72a1,1,0,0,0,1-1.07v-1.06a1,1,0,1,0-2,0v1.06A1,1,0,0,0,435.13,171.84Z"></path>
+	<path class="cls-4" d="M440.23,172.27l0-.57a1.29,1.29,0,0,1-1.19.65c-.79,0-1.32-.52-1.32-1.57V168.2h.57v2.45c0,.82.34,1.19.92,1.19s1-.35,1-1.13V168.2h.57v4.07Z"></path>
+	<path class="cls-4" d="M442.35,168.2l0,.74a1.46,1.46,0,0,1,1.43-.82v.56h-.21c-.71,0-1.19.44-1.19,1.45v2.14h-.57V168.2Z"></path>
+	<path class="cls-4" d="M447.82,168.12a1.45,1.45,0,0,1,1.55,1.56v1.1a1.49,1.49,0,0,1-1.57,1.57,1.45,1.45,0,0,1-1.55-1.56V169.7A1.48,1.48,0,0,1,447.82,168.12Zm0,3.72a1,1,0,0,0,1-1.07v-1.06a1,1,0,1,0-2,0v1.06A1,1,0,0,0,447.81,171.84Z"></path>
+	<path class="cls-4" d="M450.55,168.2l.88,3.17.82-3.17h.38l.82,3.18.89-3.18h.59l-1.23,4.07h-.5l-.78-2.91-.76,2.91h-.51l-1.22-4.07Z"></path>
+	<path class="cls-4" d="M456.07,168.2l0,.58a1.29,1.29,0,0,1,1.19-.66c.79,0,1.32.52,1.32,1.58v2.57H458v-2.44c0-.82-.34-1.19-.92-1.19s-1,.35-1,1.13v2.5h-.57V168.2Z"></path>
+	<path class="cls-4" d="M462.79,173.12a1.06,1.06,0,0,0,1.16-1.21v-.47a1.31,1.31,0,0,1-1.13.58,1.36,1.36,0,0,1-1.42-1.5v-.89a1.38,1.38,0,0,1,1.44-1.51,1.3,1.3,0,0,1,1.15.6l0-.52h.5v3.69a1.58,1.58,0,0,1-1.7,1.74,2.71,2.71,0,0,1-1.32-.28l.19-.47A2.44,2.44,0,0,0,462.79,173.12Zm.17-4.48a1,1,0,0,0-1,1.07v.74a1,1,0,1,0,2,0v-.74A1,1,0,0,0,463,168.64Z"></path>
+	<path class="cls-4" d="M467.13,168.12a1.45,1.45,0,0,1,1.55,1.56v1.1a1.48,1.48,0,0,1-1.57,1.57,1.45,1.45,0,0,1-1.55-1.56V169.7A1.48,1.48,0,0,1,467.13,168.12Zm0,3.72a1,1,0,0,0,1-1.07v-1.06a1,1,0,1,0-2,0v1.06A1,1,0,0,0,467.12,171.84Z"></path>
+	<path class="cls-4" d="M472.19,172.27l-.06-.44a1.38,1.38,0,0,1-1.16.52,1.27,1.27,0,0,1-1.41-1.25,1.3,1.3,0,0,1,1.43-1.27,1.37,1.37,0,0,1,1.08.43v-.5a1,1,0,0,0-1-1.12,2,2,0,0,0-1,.25l-.17-.45a2.22,2.22,0,0,1,1.28-.32,1.45,1.45,0,0,1,1.54,1.61v2.54Zm-.08-1.19c0-.48-.4-.82-1-.82s-1,.34-1,.82a.87.87,0,0,0,1,.83A.89.89,0,0,0,472.11,171.08Z"></path>
+	<path class="cls-4" d="M474.35,166.68v5.59h-.59v-5.59Z"></path>
+	<path class="cls-4" d="M477.39,169.46a4.13,4.13,0,0,1-1.86,3.61l-.29-.37a4.07,4.07,0,0,0,0-6.45l.29-.37A4,4,0,0,1,477.39,169.46Z"></path>
+	<path class="cls-4" d="M621.2,169.49a4.13,4.13,0,0,1,1.86-3.61l.29.37a4.06,4.06,0,0,0,0,6.46l-.29.36A4,4,0,0,1,621.2,169.49Z"></path>
+	<path class="cls-4" d="M626.53,171.19a1.19,1.19,0,0,1-1.33,1.16,2,2,0,0,1-1.37-.5l.31-.4a1.68,1.68,0,0,0,1.06.42c.48,0,.76-.28.76-.63s-.16-.6-.92-.88-1-.63-1-1.17a1.11,1.11,0,0,1,1.24-1.07,1.67,1.67,0,0,1,1.19.42l-.3.4a1.25,1.25,0,0,0-.86-.34c-.46,0-.7.28-.7.54s.17.56.8.79S626.53,170.6,626.53,171.19Z"></path>
+	<path class="cls-4" d="M628.84,172.35a1.45,1.45,0,0,1-1.55-1.56V169.7a1.48,1.48,0,0,1,1.57-1.58,1.43,1.43,0,0,1,1.52,1.56v.54h-2.52v.55a1,1,0,0,0,1,1.07,1,1,0,0,0,1-1l.53.09A1.49,1.49,0,0,1,628.84,172.35Zm1-2.55v-.13a1,1,0,1,0-2,0v.13Z"></path>
+	<path class="cls-4" d="M633.46,168.2v.46h-1.27v2.54a.56.56,0,0,0,.63.64,2.34,2.34,0,0,0,.56-.08l.08.47a2.42,2.42,0,0,1-.8.12,1,1,0,0,1-1-1.07v-2.62h-.68v-.46h.68v-1h.57v1Z"></path>
+	<path class="cls-4" d="M636.15,168.2l1.08,3.35,1.07-3.35h.59l-1.46,4.23c-.32.92-.75,1.2-1.29,1.2a1.06,1.06,0,0,1-.52-.11l.12-.45a.93.93,0,0,0,.36.06c.36,0,.63-.18.84-.86l-1.4-4.07Z"></path>
+	<path class="cls-4" d="M641,168.12a1.45,1.45,0,0,1,1.55,1.56v1.1a1.48,1.48,0,0,1-1.56,1.57,1.45,1.45,0,0,1-1.55-1.56V169.7A1.48,1.48,0,0,1,641,168.12Zm0,3.72a1,1,0,0,0,1-1.07v-1.06a1,1,0,1,0-2,0v1.06A1,1,0,0,0,641,171.84Z"></path>
+	<path class="cls-4" d="M646.12,172.27l0-.57a1.3,1.3,0,0,1-1.19.65c-.8,0-1.32-.52-1.32-1.57V168.2h.56v2.45c0,.82.35,1.19.92,1.19s1-.35,1-1.13V168.2h.56v4.07Z"></path>
+	<path class="cls-4" d="M648.23,168.2l0,.74a1.47,1.47,0,0,1,1.43-.82v.56h-.21c-.71,0-1.19.44-1.19,1.45v2.14h-.56V168.2Z"></path>
+	<path class="cls-4" d="M653.7,168.12a1.45,1.45,0,0,1,1.55,1.56v1.1a1.48,1.48,0,0,1-1.56,1.57,1.45,1.45,0,0,1-1.55-1.56V169.7A1.48,1.48,0,0,1,653.7,168.12Zm0,3.72a1,1,0,0,0,1-1.07v-1.06a1,1,0,1,0-2,0v1.06A1,1,0,0,0,653.69,171.84Z"></path>
+	<path class="cls-4" d="M656.43,168.2l.89,3.17.81-3.17h.39l.81,3.18.89-3.18h.59l-1.22,4.07h-.5l-.78-2.91-.77,2.91H657l-1.21-4.07Z"></path>
+	<path class="cls-4" d="M662,168.2l0,.58a1.29,1.29,0,0,1,1.19-.66c.8,0,1.32.52,1.32,1.58v2.57h-.56v-2.44c0-.82-.35-1.19-.92-1.19s-1,.35-1,1.13v2.5h-.56V168.2Z"></path>
+	<path class="cls-4" d="M668.67,173.12a1.07,1.07,0,0,0,1.17-1.21v-.47a1.32,1.32,0,0,1-1.14.58,1.35,1.35,0,0,1-1.41-1.5v-.89a1.38,1.38,0,0,1,1.44-1.51,1.28,1.28,0,0,1,1.14.6l0-.52h.51v3.69a1.58,1.58,0,0,1-1.71,1.74,2.76,2.76,0,0,1-1.32-.28l.2-.47A2.42,2.42,0,0,0,668.67,173.12Zm.18-4.48a1,1,0,0,0-1,1.07v.74a1,1,0,1,0,2,0v-.74A1,1,0,0,0,668.85,168.64Z"></path>
+	<path class="cls-4" d="M673,168.12a1.45,1.45,0,0,1,1.55,1.56v1.1a1.49,1.49,0,0,1-1.57,1.57,1.45,1.45,0,0,1-1.55-1.56V169.7A1.48,1.48,0,0,1,673,168.12Zm0,3.72a1,1,0,0,0,1-1.07v-1.06a1,1,0,1,0-2,0v1.06A1,1,0,0,0,673,171.84Z"></path>
+	<path class="cls-4" d="M678.08,172.27l-.06-.44a1.39,1.39,0,0,1-1.16.52,1.26,1.26,0,0,1-1.41-1.25,1.3,1.3,0,0,1,1.43-1.27,1.38,1.38,0,0,1,1.08.43v-.5a1,1,0,0,0-1.05-1.12,2,2,0,0,0-1,.25l-.18-.45a2.26,2.26,0,0,1,1.28-.32,1.45,1.45,0,0,1,1.55,1.61v2.54Zm-.08-1.19c0-.48-.41-.82-1-.82a.86.86,0,0,0-1,.82.87.87,0,0,0,1,.83A.89.89,0,0,0,678,171.08Z"></path>
+	<path class="cls-4" d="M680.24,166.68v5.59h-.59v-5.59Z"></path>
+	<path class="cls-4" d="M683.27,169.46a4.13,4.13,0,0,1-1.85,3.61l-.3-.37a4.05,4.05,0,0,0,0-6.45l.3-.37A4,4,0,0,1,683.27,169.46Z"></path>
+	<path d="M 104.3 1038.37 73.04 1001.03 104.3 963.7 166.81 963.7 198.07 1001.03 166.81 1038.37 104.3 1038.37z" class="cls-12" id="92952_48864_31855_68479"></path>
+	<path d="M 104.3 953.94 73.04 916.61 104.3 879.27 166.81 879.27 198.07 916.61 166.81 953.94 104.3 953.94z" class="cls-12" id="65433_14449_29880_79393"></path>
+	<path d="M 104.3 869.51 73.04 832.18 104.3 794.85 166.81 794.85 198.07 832.18 166.81 869.51 104.3 869.51z" class="cls-12" id="36163_91791_29464_20063"></path>
+	<path d="M 104.3 785.09 73.04 747.75 104.3 710.42 166.81 710.42 198.07 747.75 166.81 785.09 104.3 785.09z" class="cls-12" id="11338_50143_12403_66493"></path>
+	<path d="M 104.3 700.66 73.04 663.33 104.3 626 166.81 626 198.07 663.33 166.81 700.66 104.3 700.66z" class="cls-12" id="65327_79757_53636_6050"></path>
+	<path d="M 104.3 616.24 73.04 578.9 104.3 541.57 166.81 541.57 198.07 578.9 166.81 616.24 104.3 616.24z" class="cls-12" id="71174_61735_28650_75914"></path>
+	<path d="M 104.3 531.81 73.04 494.48 104.3 457.14 166.81 457.14 198.07 494.48 166.81 531.81 104.3 531.81z" class="cls-12" id="84959_62704_99559_55408"></path>
+	<path d="M 104.3 447.39 73.04 410.05 104.3 372.72 166.81 372.72 198.07 410.05 166.81 447.39 104.3 447.39z" class="cls-12" id="62112_61639_12572_92043"></path>
+	<path d="M 104.3 362.96 73.04 325.63 104.3 288.29 166.81 288.29 198.07 325.63 166.81 362.96 104.3 362.96z" class="cls-12" id="35375_84725_20448_13848"></path>
+	<path d="M 104.3 278.54 73.04 241.2 104.3 203.87 166.81 203.87 198.07 241.2 166.81 278.54 104.3 278.54z" class="cls-12" id="74447_55753_41021_16062"></path>
+	<path d="M 208.2 1081.19 176.95 1043.86 208.2 1006.52 270.72 1006.52 301.98 1043.86 270.72 1081.19 208.2 1081.19z" class="cls-12" id="77060_59386_44853_9512"></path>
+	<path d="M 208.2 996.76 176.95 959.43 208.2 922.1 270.72 922.1 301.98 959.43 270.72 996.76 208.2 996.76z" class="cls-12" id="82491_22373_12758_32174"></path>
+	<path d="M 208.2 912.34 176.95 875 208.2 837.67 270.72 837.67 301.98 875 270.72 912.34 208.2 912.34z" class="cls-12" id="78642_69111_53392_98284"></path>
+	<path d="M 208.2 827.91 176.95 790.58 208.2 753.24 270.72 753.24 301.98 790.58 270.72 827.91 208.2 827.91z" class="cls-12" id="23646_70165_33178_72917"></path>
+	<path d="M 208.2 743.49 176.95 706.15 208.2 668.82 270.72 668.82 301.98 706.15 270.72 743.49 208.2 743.49z" class="cls-12" id="37028_85942_93062_61259"></path>
+	<path d="M 208.2 659.06 176.95 621.73 208.2 584.39 270.72 584.39 301.98 621.73 270.72 659.06 208.2 659.06z" class="cls-12" id="20414_35946_71013_52898"></path>
+	<path d="M 208.2 574.64 176.95 537.3 208.2 499.97 270.72 499.97 301.98 537.3 270.72 574.64 208.2 574.64z" class="cls-12" id="53828_58913_75339_97797"></path>
+	<path d="M 208.2 490.21 176.95 452.88 208.2 415.54 270.72 415.54 301.98 452.88 270.72 490.21 208.2 490.21z" class="cls-12" id="12070_89365_26365_86910"></path>
+	<path d="M 208.2 405.79 176.95 368.45 208.2 331.12 270.72 331.12 301.98 368.45 270.72 405.79 208.2 405.79z" class="cls-12" id="80251_149_53188_65943"></path>
+	<path d="M 208.2 321.36 176.95 284.03 208.2 246.69 270.72 246.69 301.98 284.03 270.72 321.36 208.2 321.36z" class="cls-12" id="52684_52849_14547_28838"></path>
+	<path d="M 208.2 236.93 176.95 199.6 208.2 162.26 270.72 162.26 301.98 199.6 270.72 236.93 208.2 236.93z" class="cls-12" id="79752_72450_12031_51399"></path>
+	<path d="M 310.46 1038.98 279.21 1001.64 310.46 964.31 372.98 964.31 404.24 1001.64 372.98 1038.98 310.46 1038.98z" class="cls-12" id="79329_70474_33200_23066"></path>
+	<path d="M 310.46 954.55 279.21 917.22 310.46 879.88 372.98 879.88 404.24 917.22 372.98 954.55 310.46 954.55z" class="cls-12" id="88218_96668_50260_14060"></path>
+	<path d="M 310.46 870.13 279.21 832.79 310.46 795.46 372.98 795.46 404.24 832.79 372.98 870.13 310.46 870.13z" class="cls-12" id="28006_37614_61978_66399"></path>
+	<path d="M 310.46 785.7 279.21 748.37 310.46 711.03 372.98 711.03 404.24 748.37 372.98 785.7 310.46 785.7z" class="cls-12" id="28952_84052_38082_28101"></path>
+	<path d="M 310.46 701.28 279.21 663.94 310.46 626.61 372.98 626.61 404.24 663.94 372.98 701.28 310.46 701.28z" class="cls-12" id="38916_88296_92886_42037"></path>
+	<path d="M 310.46 616.85 279.21 579.52 310.46 542.18 372.98 542.18 404.24 579.52 372.98 616.85 310.46 616.85z" class="cls-12" id="38748_86348_18364_12767"></path>
+	<path d="M 310.46 532.42 279.21 495.09 310.46 457.76 372.98 457.76 404.24 495.09 372.98 532.42 310.46 532.42z" class="cls-12" id="12732_6875_90933_69557"></path>
+	<path d="M 310.46 448 279.21 410.67 310.46 373.33 372.98 373.33 404.24 410.67 372.98 448 310.46 448z" class="cls-12" id="92160_92396_47135_2854"></path>
+	<path d="M 310.46 363.57 279.21 326.24 310.46 288.9 372.98 288.9 404.24 326.24 372.98 363.57 310.46 363.57z" class="cls-12" id="5375_52756_10714_39234"></path>
+	<path d="M 310.46 279.15 279.21 241.81 310.46 204.48 372.98 204.48 404.24 241.81 372.98 279.15 310.46 279.15z" class="cls-12" id="66852_67677_52829_72995"></path>
+	<path d="M 414.37 1081.8 383.12 1044.47 414.37 1007.13 476.89 1007.13 508.14 1044.47 476.89 1081.8 414.37 1081.8z" class="cls-12" id="23790_2408_88477_49372"></path>
+	<path d="M 414.37 997.38 383.12 960.04 414.37 922.71 476.89 922.71 508.14 960.04 476.89 997.38 414.37 997.38z" class="cls-12" id="88127_40276_78829_91105"></path>
+	<path d="M 414.37 912.95 383.12 875.62 414.37 838.28 476.89 838.28 508.14 875.62 476.89 912.95 414.37 912.95z" class="cls-12" id="71754_19971_92704_33025"></path>
+	<path d="M 414.37 828.53 383.12 791.19 414.37 753.86 476.89 753.86 508.14 791.19 476.89 828.53 414.37 828.53z" class="cls-12" id="49659_25554_56505_28812"></path>
+	<path d="M 414.37 744.1 383.12 706.77 414.37 669.43 476.89 669.43 508.14 706.77 476.89 744.1 414.37 744.1z" class="cls-12" id="57634_50197_30505_79230"></path>
+	<path d="M 414.37 659.67 383.12 622.34 414.37 585 476.89 585 508.14 622.34 476.89 659.67 414.37 659.67z" class="cls-12" id="12435_21403_64117_18008"></path>
+	<path d="M 414.37 575.25 383.12 537.91 414.37 500.58 476.89 500.58 508.14 537.91 476.89 575.25 414.37 575.25z" class="cls-12" id="43094_55363_22821_15781"></path>
+	<path d="M 414.37 490.82 383.12 453.49 414.37 416.15 476.89 416.15 508.14 453.49 476.89 490.82 414.37 490.82z" class="cls-12" id="59104_20390_28138_70240"></path>
+	<path d="M 414.37 406.4 383.12 369.06 414.37 331.73 476.89 331.73 508.14 369.06 476.89 406.4 414.37 406.4z" class="cls-12" id="41186_38411_30782_66816"></path>
+	<path d="M 414.37 321.97 383.12 284.64 414.37 247.3 476.89 247.3 508.14 284.64 476.89 321.97 414.37 321.97z" class="cls-12" id="94260_60340_23887_41006"></path>
+	<path d="M 414.37 237.55 383.12 200.21 414.37 162.88 476.89 162.88 508.14 200.21 476.89 237.55 414.37 237.55z" class="cls-12" id="66304_350_37684_20002"></path>
+	<path d="M 516.63 1039.23 485.38 1001.89 516.63 964.56 579.15 964.56 610.4 1001.89 579.15 1039.23 516.63 1039.23z" class="cls-12" id="35855_6436_95991_18659"></path>
+	<path d="M 516.63 954.8 485.38 917.47 516.63 880.13 579.15 880.13 610.4 917.47 579.15 954.8 516.63 954.8z" class="cls-12" id="10045_61954_37294_92127"></path>
+	<path d="M 516.63 870.38 485.38 833.04 516.63 795.71 579.15 795.71 610.4 833.04 579.15 870.38 516.63 870.38z" class="cls-12" id="27914_31097_23035_18117"></path>
+	<path d="M 516.63 785.95 485.38 748.62 516.63 711.28 579.15 711.28 610.4 748.62 579.15 785.95 516.63 785.95z" class="cls-12" id="79483_93228_38585_99049"></path>
+	<path d="M 516.63 701.53 485.38 664.19 516.63 626.86 579.15 626.86 610.4 664.19 579.15 701.53 516.63 701.53z" class="cls-12" id="95810_17655_88897_93818"></path>
+	<path d="M 516.63 617.1 485.38 579.77 516.63 542.43 579.15 542.43 610.4 579.77 579.15 617.1 516.63 617.1z" class="cls-12" id="12476_89189_13131_46513"></path>
+	<path d="M 516.63 532.67 485.38 495.34 516.63 458 579.15 458 610.4 495.34 579.15 532.67 516.63 532.67z" class="cls-12" id="48545_86896_33667_26661"></path>
+	<path d="M 516.63 448.25 485.38 410.92 516.63 373.58 579.15 373.58 610.4 410.92 579.15 448.25 516.63 448.25z" class="cls-12" id="72382_3927_91095_88365"></path>
+	<path d="M 516.63 363.82 485.38 326.49 516.63 289.15 579.15 289.15 610.4 326.49 579.15 363.82 516.63 363.82z" class="cls-12" id="1787_17814_18186_96861"></path>
+	<path d="M 516.63 279.4 485.38 242.06 516.63 204.73 579.15 204.73 610.4 242.06 579.15 279.4 516.63 279.4z" class="cls-12" id="25666_4917_11562_84144"></path>
+	<path d="M 620.54 1082.05 589.28 1044.72 620.54 1007.38 683.05 1007.38 714.31 1044.72 683.05 1082.05 620.54 1082.05z" class="cls-12" id="48383_12979_53278_36524"></path>
+	<path d="M 620.54 997.63 589.28 960.29 620.54 922.96 683.05 922.96 714.31 960.29 683.05 997.63 620.54 997.63z" class="cls-12" id="59515_51061_37496_20265"></path>
+	<path d="M 620.54 913.2 589.28 875.87 620.54 838.53 683.05 838.53 714.31 875.87 683.05 913.2 620.54 913.2z" class="cls-12" id="85990_94140_3754_71690"></path>
+	<path d="M 620.54 828.77 589.28 791.44 620.54 754.11 683.05 754.11 714.31 791.44 683.05 828.77 620.54 828.77z" class="cls-12" id="97548_4574_67301_48455"></path>
+	<path d="M 620.54 744.35 589.28 707.01 620.54 669.68 683.05 669.68 714.31 707.01 683.05 744.35 620.54 744.35z" class="cls-12" id="34107_44659_69089_84654"></path>
+	<path d="M 620.54 659.92 589.28 622.59 620.54 585.25 683.05 585.25 714.31 622.59 683.05 659.92 620.54 659.92z" class="cls-12" id="21700_93478_53076_8108"></path>
+	<path d="M 620.54 575.5 589.28 538.16 620.54 500.83 683.05 500.83 714.31 538.16 683.05 575.5 620.54 575.5z" class="cls-12" id="17538_39376_80550_83960"></path>
+	<path d="M 620.54 491.07 589.28 453.74 620.54 416.4 683.05 416.4 714.31 453.74 683.05 491.07 620.54 491.07z" class="cls-12" id="85116_38854_64689_65850"></path>
+	<path d="M 620.54 406.65 589.28 369.31 620.54 331.98 683.05 331.98 714.31 369.31 683.05 406.65 620.54 406.65z" class="cls-12" id="12658_88895_84493_16887"></path>
+	<path d="M 620.54 322.22 589.28 284.89 620.54 247.55 683.05 247.55 714.31 284.89 683.05 322.22 620.54 322.22z" class="cls-12" id="52228_18693_39304_94674"></path>
+	<path d="M 620.54 237.8 589.28 200.46 620.54 163.13 683.05 163.13 714.31 200.46 683.05 237.8 620.54 237.8z" class="cls-12" id="27032_55898_13409_58982"></path>
+	<path d="M 722.8 1039.84 691.54 1002.5 722.8 965.17 785.32 965.17 816.57 1002.5 785.32 1039.84 722.8 1039.84z" class="cls-12" id="26899_6619_44786_5308"></path>
+	<path d="M 722.8 955.41 691.54 918.08 722.8 880.75 785.32 880.75 816.57 918.08 785.32 955.41 722.8 955.41z" class="cls-12" id="38819_18841_85972_96127"></path>
+	<path d="M 722.8 870.99 691.54 833.65 722.8 796.32 785.32 796.32 816.57 833.65 785.32 870.99 722.8 870.99z" class="cls-12" id="41765_50312_70957_48961"></path>
+	<path d="M 722.8 786.56 691.54 749.23 722.8 711.89 785.32 711.89 816.57 749.23 785.32 786.56 722.8 786.56z" class="cls-12" id="3951_96894_98043_92487"></path>
+	<path d="M 722.8 702.14 691.54 664.8 722.8 627.47 785.32 627.47 816.57 664.8 785.32 702.14 722.8 702.14z" class="cls-12" id="79577_79494_94810_55384"></path>
+	<path d="M 722.8 617.71 691.54 580.38 722.8 543.04 785.32 543.04 816.57 580.38 785.32 617.71 722.8 617.71z" class="cls-12" id="8322_31459_69063_74420"></path>
+	<path d="M 722.8 533.29 691.54 495.95 722.8 458.62 785.32 458.62 816.57 495.95 785.32 533.29 722.8 533.29z" class="cls-12" id="83579_69793_65191_16912"></path>
+	<path d="M 722.8 448.86 691.54 411.53 722.8 374.19 785.32 374.19 816.57 411.53 785.32 448.86 722.8 448.86z" class="cls-12" id="17163_18247_61303_37446"></path>
+	<path d="M 722.8 364.44 691.54 327.1 722.8 289.77 785.32 289.77 816.57 327.1 785.32 364.44 722.8 364.44z" class="cls-12" id="34682_60260_9632_56186"></path>
+	<path d="M 722.8 280.01 691.54 242.68 722.8 205.34 785.32 205.34 816.57 242.68 785.32 280.01 722.8 280.01z" class="cls-12" id="4647_48463_78599_30999"></path>
+
+	<g id="description">
+		<text x="0" y="0" text-anchor="middle" font-family="Uniform-Condensed6" xml:space="preserve">
+			<tspan x="420.95" y="130" text-anchor="middle">Use for individuals or as a group by picking a colour each and coloring in a part of the box.  Everyone’s journey is different and you can</tspan>
+		</text>
+		<text x="0" y="0" text-anchor="middle" font-family="Uniform-Condensed6" xml:space="preserve">
+			<tspan x="415" y="140" text-anchor="middle">interpret the goals flexibly.  The aim is to inspire you to learn and try new things.  Not everything needs to be completed.</tspan>
+		</text>
+	</g>
+
+	<text class="cls-15" transform="translate(731.19 1146.12)" font-family="Uniform-Condensed6">CC BY-NC-SA 4.0</text>
+
+	<text class="cls-16" transform="translate(9.88 1177)" font-family="Uniform-Condensed6">github.com/sjpiper145/MakerSkillTree</text>
+
+	
+	<text id="credits" class="cls-8" y="0" x="0" font-family="Uniform-Condensed6" aria-expanded="false" style="font-size: 16px !important">
+		<tspan y="1177.5" x="420.95" text-anchor="middle" xml:space="preserve">MADE BY Visit the a website on TOR</tspan>
+	</text>
+
+	<g id="score" transform="translate(-1,0)">
+
+		<path class="cls-22" d="M842.18,1067.05v53c-.3,0-.6,0-.91,0H754.49c-7,0-12.76-5.1-12.76-11.4v-30.23c0-6.3,5.71-11.4,12.76-11.4h86.78C841.58,1067,841.88,1067,842.18,1067.05Z"></path>
+		<path class="cls-4" d="M842.18,1101.68V1120c-.3,0-.6,0-.91,0H754.49c-7,0-12.76-5.1-12.76-11.4v-7Z"></path>
+		<text class="cls-23" transform="translate(769.28 1114.72)">
+			Total Score
+		</text>
+		<text class="cls-28" transform="translate(769.43 1063.02)">
+			1 tile = 1 point
+		</text>
+	</g>
+<text x="135.54000091552734" y="964.7000122070312" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="135.54000091552734" dy="1em">Understand </tspan><tspan x="135.54000091552734" dy="1.2em">HTTPS</tspan></text><text x="135.54000091552734" y="880.27001953125" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="135.54000091552734" dy="1em">Do a personal </tspan><tspan x="135.54000091552734" dy="1.2em">data review and </tspan><tspan x="135.54000091552734" dy="1.2em">clean</tspan></text><text x="135.54000091552734" y="795.8499755859375" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="135.54000091552734" dy="1em">Delete your </tspan><tspan x="135.54000091552734" dy="1.2em">unused accounts</tspan></text><text x="135.54000091552734" y="711.4199829101562" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="135.54000091552734" dy="1em">Learn about </tspan><tspan x="135.54000091552734" dy="1.2em">local privacy laws</tspan></text><text x="135.54000091552734" y="627" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="135.54000091552734" dy="1em">Re-install an </tspan><tspan x="135.54000091552734" dy="1.2em">operating system</tspan></text><text x="135.54000091552734" y="542.5700073242188" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="135.54000091552734" dy="1em">Use Kali Linux</tspan></text><text x="135.54000091552734" y="458.1400146484375" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="135.54000091552734" dy="1em">Teach a friend </tspan><tspan x="135.54000091552734" dy="1.2em">a cybersecurity skill</tspan></text><text x="135.54000091552734" y="373.7200012207031" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="135.54000091552734" dy="1em">Listen to a </tspan><tspan x="135.54000091552734" dy="1.2em">security podcast</tspan></text><text x="135.54000091552734" y="289.2900085449219" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="135.54000091552734" dy="1em">Attend a </tspan><tspan x="135.54000091552734" dy="1.2em">security </tspan><tspan x="135.54000091552734" dy="1.2em">conference</tspan></text><text x="239.4499969482422" y="1007.52001953125" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="239.4499969482422" dy="1em">Turn on local </tspan><tspan x="239.4499969482422" dy="1.2em">backups e.g. Time </tspan><tspan x="239.4499969482422" dy="1.2em">Machine</tspan></text><text x="239.4499969482422" y="923.0999755859375" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="239.4499969482422" dy="1em">Get an </tspan><tspan x="239.4499969482422" dy="1.2em">Adblocker</tspan></text><text x="239.4499969482422" y="838.6699829101562" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="239.4499969482422" dy="1em">Switch to end </tspan><tspan x="239.4499969482422" dy="1.2em">to end encrypted </tspan><tspan x="239.4499969482422" dy="1.2em">messaging</tspan></text><text x="239.4499969482422" y="754.239990234375" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="239.4499969482422" dy="1em">Create a </tspan><tspan x="239.4499969482422" dy="1.2em">separate WiFi </tspan><tspan x="239.4499969482422" dy="1.2em">network for guests and </tspan><tspan x="239.4499969482422" dy="1.2em">light bulbs</tspan></text><text x="239.4499969482422" y="669.8200073242188" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="239.4499969482422" dy="1em">Learn about </tspan><tspan x="239.4499969482422" dy="1.2em">keylogging</tspan></text><text x="239.4499969482422" y="585.3900146484375" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="239.4499969482422" dy="1em">Learn about </tspan><tspan x="239.4499969482422" dy="1.2em">firewall settings</tspan></text><text x="239.4499969482422" y="500.9700012207031" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="239.4499969482422" dy="1em">Encrypt your </tspan><tspan x="239.4499969482422" dy="1.2em">devices</tspan></text><text x="239.4499969482422" y="416.5400085449219" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="239.4499969482422" dy="1em">Learn how to </tspan><tspan x="239.4499969482422" dy="1.2em">use SSH</tspan></text><text x="239.4499969482422" y="332.1199951171875" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="239.4499969482422" dy="1em">Use Wireshark </tspan><tspan x="239.4499969482422" dy="1.2em">to see what your </tspan><tspan x="239.4499969482422" dy="1.2em">Smart TV is up to</tspan></text><text x="239.4499969482422" y="247.69000244140625" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="239.4499969482422" dy="1em">Participate in a </tspan><tspan x="239.4499969482422" dy="1.2em">capture the flag </tspan><tspan x="239.4499969482422" dy="1.2em">activity</tspan></text><text x="341.7099914550781" y="965.3099975585938" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="341.7099914550781" dy="1em">Update your </tspan><tspan x="341.7099914550781" dy="1.2em">router password</tspan></text><text x="341.7099914550781" y="880.8800048828125" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="341.7099914550781" dy="1em">Sign up for </tspan><tspan x="341.7099914550781" dy="1.2em">'Have I been pwnd?'</tspan></text><text x="341.7099914550781" y="796.4600219726562" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="341.7099914550781" dy="1em">Use a malware </tspan><tspan x="341.7099914550781" dy="1.2em">scanner</tspan></text><text x="341.7099914550781" y="712.030029296875" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="341.7099914550781" dy="1em">Learn about </tspan><tspan x="341.7099914550781" dy="1.2em">ethical hacking</tspan></text><text x="341.7099914550781" y="627.6099853515625" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="341.7099914550781" dy="1em">Decide if you </tspan><tspan x="341.7099914550781" dy="1.2em">should fear the </tspan><tspan x="341.7099914550781" dy="1.2em">dark web</tspan></text><text x="341.7099914550781" y="543.1799926757812" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="341.7099914550781" dy="1em">Use osquery to </tspan><tspan x="341.7099914550781" dy="1.2em">list your browser </tspan><tspan x="341.7099914550781" dy="1.2em">addons</tspan></text><text x="341.7099914550781" y="458.760009765625" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="341.7099914550781" dy="1em">Learn about </tspan><tspan x="341.7099914550781" dy="1.2em">Zero Trust</tspan></text><text x="341.7099914550781" y="374.3299865722656" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="341.7099914550781" dy="1em">Make your own </tspan><tspan x="341.7099914550781" dy="1.2em">BadUSB</tspan></text><text x="341.7099914550781" y="289.8999938964844" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="341.7099914550781" dy="1em">Get a security </tspan><tspan x="341.7099914550781" dy="1.2em">certification</tspan></text><text x="341.7099914550781" y="205.47999572753906" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="341.7099914550781" dy="1em">Teach a class </tspan><tspan x="341.7099914550781" dy="1.2em">on cybersecurity</tspan></text><text x="445.6199951171875" y="1008.1300048828125" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="445.6199951171875" dy="1em">Update your </tspan><tspan x="445.6199951171875" dy="1.2em">operating system</tspan></text><text x="445.6199951171875" y="923.7100219726562" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="445.6199951171875" dy="1em">Block and </tspan><tspan x="445.6199951171875" dy="1.2em">report a scam</tspan></text><text x="445.6199951171875" y="839.280029296875" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="445.6199951171875" dy="1em">Protect </tspan><tspan x="445.6199951171875" dy="1.2em">yourself from RFID </tspan><tspan x="445.6199951171875" dy="1.2em">cloning</tspan></text><text x="445.6199951171875" y="754.8599853515625" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="445.6199951171875" dy="1em">Learn about </tspan><tspan x="445.6199951171875" dy="1.2em">malware, </tspan><tspan x="445.6199951171875" dy="1.2em">ransomware and recent </tspan><tspan x="445.6199951171875" dy="1.2em">threats</tspan></text><text x="445.6199951171875" y="670.4299926757812" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="445.6199951171875" dy="1em">Learn about </tspan><tspan x="445.6199951171875" dy="1.2em">responsible </tspan><tspan x="445.6199951171875" dy="1.2em">disclosure</tspan></text><text x="445.6199951171875" y="586" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="445.6199951171875" dy="1em">Read a CVE </tspan><tspan x="445.6199951171875" dy="1.2em">that's in the news</tspan></text><text x="445.6199951171875" y="501.5799865722656" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="445.6199951171875" dy="1em">Explore the </tspan><tspan x="445.6199951171875" dy="1.2em">kinds of multi-</tspan><tspan x="445.6199951171875" dy="1.2em">factor authentication</tspan></text><text x="445.6199951171875" y="417.1499938964844" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="445.6199951171875" dy="1em">Set up a VPN </tspan><tspan x="445.6199951171875" dy="1.2em">to your home </tspan><tspan x="445.6199951171875" dy="1.2em">router</tspan></text><text x="445.6199951171875" y="332.7300109863281" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="445.6199951171875" dy="1em">Use photorec </tspan><tspan x="445.6199951171875" dy="1.2em">to recover deleted </tspan><tspan x="445.6199951171875" dy="1.2em">files</tspan></text><text x="445.6199951171875" y="248.3000030517578" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="445.6199951171875" dy="1em">Participate in a </tspan><tspan x="445.6199951171875" dy="1.2em">red team vs. blue </tspan><tspan x="445.6199951171875" dy="1.2em">team activity</tspan></text><text x="547.8800048828125" y="965.5599975585938" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="547.8800048828125" dy="1em">Manage your </tspan><tspan x="547.8800048828125" dy="1.2em">privacy settings on </tspan><tspan x="547.8800048828125" dy="1.2em">social media</tspan></text><text x="547.8800048828125" y="881.1300048828125" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="547.8800048828125" dy="1em">Understand </tspan><tspan x="547.8800048828125" dy="1.2em">security risks of </tspan><tspan x="547.8800048828125" dy="1.2em">bluetooth</tspan></text><text x="547.8800048828125" y="796.7100219726562" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="547.8800048828125" dy="1em">Learn about </tspan><tspan x="547.8800048828125" dy="1.2em">the OWASP Top Ten</tspan></text><text x="547.8800048828125" y="712.280029296875" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="547.8800048828125" dy="1em">Practice social </tspan><tspan x="547.8800048828125" dy="1.2em">engineering with a </tspan><tspan x="547.8800048828125" dy="1.2em">friend</tspan></text><text x="547.8800048828125" y="627.8599853515625" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="547.8800048828125" dy="1em">Learn about </tspan><tspan x="547.8800048828125" dy="1.2em">local cybersecurity </tspan><tspan x="547.8800048828125" dy="1.2em">laws</tspan></text><text x="547.8800048828125" y="543.4299926757812" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="547.8800048828125" dy="1em">Learn about </tspan><tspan x="547.8800048828125" dy="1.2em">federated identity </tspan><tspan x="547.8800048828125" dy="1.2em">technologies</tspan></text><text x="547.8800048828125" y="459" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="547.8800048828125" dy="1em">Understand </tspan><tspan x="547.8800048828125" dy="1.2em">the implications </tspan><tspan x="547.8800048828125" dy="1.2em">and risks of data leaks</tspan></text><text x="547.8800048828125" y="374.5799865722656" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="547.8800048828125" dy="1em">Use Nmap to </tspan><tspan x="547.8800048828125" dy="1.2em">look for holes in </tspan><tspan x="547.8800048828125" dy="1.2em">your firewall</tspan></text><text x="547.8800048828125" y="290.1499938964844" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="547.8800048828125" dy="1em">Learn about </tspan><tspan x="547.8800048828125" dy="1.2em">identity </tspan><tspan x="547.8800048828125" dy="1.2em">management</tspan></text><text x="547.8800048828125" y="205.72999572753906" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="547.8800048828125" dy="1em">Claim a bug </tspan><tspan x="547.8800048828125" dy="1.2em">bounty</tspan></text><text x="651.780029296875" y="1008.3800048828125" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="651.780029296875" dy="1em">Enable </tspan><tspan x="651.780029296875" dy="1.2em">automatic updates</tspan></text><text x="651.780029296875" y="923.9600219726562" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="651.780029296875" dy="1em">Set up 2 factor </tspan><tspan x="651.780029296875" dy="1.2em">authentication or a </tspan><tspan x="651.780029296875" dy="1.2em">passkey</tspan></text><text x="651.780029296875" y="839.530029296875" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="651.780029296875" dy="1em">View the </tspan><tspan x="651.780029296875" dy="1.2em">source code of a </tspan><tspan x="651.780029296875" dy="1.2em">website</tspan></text><text x="651.780029296875" y="755.1099853515625" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="651.780029296875" dy="1em">Review and </tspan><tspan x="651.780029296875" dy="1.2em">remove unused </tspan><tspan x="651.780029296875" dy="1.2em">software</tspan></text><text x="651.780029296875" y="670.6799926757812" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="651.780029296875" dy="1em">Visit the BBC </tspan><tspan x="651.780029296875" dy="1.2em">on TOR</tspan></text><text x="651.780029296875" y="586.25" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="651.780029296875" dy="1em">Create a </tspan><tspan x="651.780029296875" dy="1.2em">personal threat </tspan><tspan x="651.780029296875" dy="1.2em">model</tspan></text><text x="651.780029296875" y="501.8299865722656" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="651.780029296875" dy="1em">Understand </tspan><tspan x="651.780029296875" dy="1.2em">the limitations of </tspan><tspan x="651.780029296875" dy="1.2em">email security </tspan><tspan x="651.780029296875" dy="1.2em">techniques</tspan></text><text x="651.780029296875" y="417.3999938964844" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="651.780029296875" dy="1em">Set up multiple </tspan><tspan x="651.780029296875" dy="1.2em">backups for files</tspan></text><text x="651.780029296875" y="332.9800109863281" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="651.780029296875" dy="1em">Make an </tspan><tspan x="651.780029296875" dy="1.2em">emergency </tspan><tspan x="651.780029296875" dy="1.2em">mitigation plan</tspan></text><text x="651.780029296875" y="248.5500030517578" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="651.780029296875" dy="1em">Learn about </tspan><tspan x="651.780029296875" dy="1.2em">NIST Frameworks</tspan></text><text x="754.0399780273438" y="966.1699829101562" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="754.0399780273438" dy="1em">Spot a scam </tspan><tspan x="754.0399780273438" dy="1.2em">email or text</tspan></text><text x="754.0399780273438" y="881.75" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="754.0399780273438" dy="1em">Set up a </tspan><tspan x="754.0399780273438" dy="1.2em">password manager</tspan></text><text x="754.0399780273438" y="797.3200073242188" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="754.0399780273438" dy="1em">Replace your </tspan><tspan x="754.0399780273438" dy="1.2em">outdated </tspan><tspan x="754.0399780273438" dy="1.2em">passwords</tspan></text><text x="754.0399780273438" y="712.8900146484375" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="754.0399780273438" dy="1em">Understand </tspan><tspan x="754.0399780273438" dy="1.2em">browser </tspan><tspan x="754.0399780273438" dy="1.2em">fingerprinting and user </tspan><tspan x="754.0399780273438" dy="1.2em">tracking</tspan></text><text x="754.0399780273438" y="628.469970703125" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="754.0399780273438" dy="1em">Lose sleep </tspan><tspan x="754.0399780273438" dy="1.2em">from your </tspan><tspan x="754.0399780273438" dy="1.2em">newfound knowledge</tspan></text><text x="754.0399780273438" y="544.0399780273438" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="754.0399780273438" dy="1em">Learn about </tspan><tspan x="754.0399780273438" dy="1.2em">PKI, X.509, and </tspan><tspan x="754.0399780273438" dy="1.2em">Root-CAs</tspan></text><text x="754.0399780273438" y="459.6199951171875" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="754.0399780273438" dy="1em">Send a secure </tspan><tspan x="754.0399780273438" dy="1.2em">message with GPG</tspan></text><text x="754.0399780273438" y="375.19000244140625" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="754.0399780273438" dy="1em">Set up a </tspan><tspan x="754.0399780273438" dy="1.2em">website with Let's </tspan><tspan x="754.0399780273438" dy="1.2em">Encrypt</tspan></text><text x="754.0399780273438" y="290.7699890136719" class="textbox-inner " text-anchor="middle" font-family="Uniform-Condensed6"><tspan x="754.0399780273438" dy="1em">Protect a </tspan><tspan x="754.0399780273438" dy="1.2em">server from brute </tspan><tspan x="754.0399780273438" dy="1.2em">force attacks.</tspan></text><text x="0" y="0" class="cls-19 header" text-anchor="middle"><tspan text-anchor="middle" x="420.95" class="cls-19 header" y="65">IT SECURITY</tspan></text></svg>


### PR DESCRIPTION
My peer review for the IT security skill tree. 

High level things I tried to do:

* Shift the focus from professional topics to those more hobbyist friendly.
* Moved to more evergreen topics like "malware" from "rootkits".
* Change many of the "Learn about X" to an action oriented version.
* Replace some of the more generic items with additional security toipcs.

Notes roughly following the [Keep A Changelog](https://keepachangelog.com/en/1.0.0/) format (Should I add a CHANGELOG to the PR?)

```
## 2025-02-23

### Added

* "Create a personal threat model" -- Good way to get started thinking about security and judging risk. https://arstechnica.com/information-technology/2017/07/how-i-learned-to-stop-worrying-mostly-and-love-my-threat-model/
* "Make your own BadUSB" -- Introduction to USB/hardware based attacks and automation.
* "Create a separate WiFi network for guests and light bulbs" -- Dipping your toes into learning about securing networks.
* "Attend a security conference" -- Community engagement.
* "Listen to a security podcast" -- Continuing education is key in security.
* "Decide if you should fear the dark web" -- Jumping off point to learning about the dark web, both the pros and cons.
* "Practice social engineering with a friend" -- Safe way to start investigating these extremely common techniques.
* "Learn about ethical hacking" -- Can open the doors to ethics, privacy, and a whole lot of history of people doing things that are questionable in the name of good.
* "Use osquery to list your browser addons" -- Open source way to get experience with the kind of things that endpoint monitoring tools do. I thought about leaving this open ended, but there's a lot of vendors in this space and I wouldn't want people getting sucked into buying things to try as a hobby.
* "Use photorec to recover deleted files" -- good jumping off point for digital forensics and secure deletion. This could be more open ended like "Try recovering deleted files".
* "Learn about federated identity technologies" -- Jumping off point for SAML, OIDC, SSO, JWTs, etc. Used to be very enterprise but are becoming more common and tying this list to a specific tech is going to date it.
* "Delete your unused accounts"
* "Lose sleep from your newfound knowledge" -- A right of passage.

### Changed

* "Learn to use wireshark responsibly" -> "Use Wireshark to see what your Smart TV is up to" -- Capitalization, focus on a specific fun goal as a jumping off point.
* "Take the LPI Security Essentials Exam" -> "Get a security certification" -- Broadening scope.
* "Learn to use Nmap responsibly" -> "Use Nmap to look for holes in your firewall" -- Focus on an action as a jumping off point.
* "Learn about OTP and TOTP" -> "Explore the kinds of multi-factor authentication." -- Broadens to security keys, passkeys, OTP, biometrics.
* "Learn about Firewall settings & iptables/nftables" -> "Learn about firewall settings" -- Removes Linux specifics not applicable to most people.
* "Set up backups for your data" -> "Turn on local backups e.g. Time Machine" -- Most beginner friendly is local backups.
* "Change the default name and password on router" -> "Update your router password" -- Default names and passwords are becoming a thing of the past due to [new regulations](https://arstechnica.com/gadgets/2024/04/connected-devices-with-awful-default-passwords-now-illegal-in-uk/).
* "Learn about TOR" -> "Visit the BBC on TOR" -- Using a well known website to show legitimate uses of the dark web for security purposes.
* "Protect a website by limiting login attempts" -> "Protect a server from brute force attacks." -- Make more general.
* "Update your operating system on mobile" -> "Enable automatic updates" -- Most consumer OS' now have auto-update because people were so bad at updating.
* "Use a rootkit scanner" -> "Use a malware scanner" -- Rootkits are less of a concern now than they used to be before EFI.
* "Learn about SQL Injections" -> "Learn about the OWASP Top Ten" -- This encompasses injections and will be evergreen because the list is updated to reflect real systems.
* "Get a VPN" -> "Set up a VPN to your home router" -- VPNs are pretty sketchy [Tom Scott has a good video about it](https://www.youtube.com/watch?v=WVDQEoe6ZWY)
* "Learn how to use GPG" -> "Send a secure message with GPG" -- Action oriented
* "Learn about RFID / NFC Basics" -> "Protect yourself from RFID cloning" -- Focusing on the security aspect, NFC is a subset of RFID.
* "Understand use of S/MIME" -> "Understand the limitations of email security techniques" -- S/MIME is very government/enterprise focused and is at best a band-aid with many of its own faults.
* "Learn to encrypt your devices" -> "Encrypt your devices" -- Action oriented
* "Learn about end to end encryption" -> "Switch to end to end encrypted messaging" -- Action oriented
* "Set up a website with a TLS cert" -> "Set up a website with Let's Encrypt" -- Suggest a free/modern way to do this.
* "Learn about PKI, Certificate Authorities and Trusted Root CAs" -> "Learn about PKI, X.509, and Root-CAs" -- Merging a few items related to the way the Internet is secured.
* "Read CVE Details" -> "Read a CVE that's in the news" -- Most CVEs have almost no info, but the big ones often do.
* "Use complex passwords, never used twice" -> "Replace your outdated passwords" -- Fixing your current security posture vs going forward.

### Removed

* "Build an IT management system" -- This outcome is vague (asset management, identity management, policy management, threat management?) and focused on industry.
* "Learn about unencrypted and public WiFi" -- This is less important now that most sites are TLS encrypted, WiFi access points are encrypted, and OS' have different settings for shared vs home networks.
* "Learn about Wardriving" -- This is an older technique, search trends for it are down https://trends.google.com/trends/explore?date=all&q=%2Fm%2F01fqw8 and it may not be applicable for much longer as stricter security laws come into place: https://arstechnica.com/gadgets/2024/04/connected-devices-with-awful-default-passwords-now-illegal-in-uk/
* "Read the Docs" -- Too generic
* "Participate in a Hackathon" -- Not IT security focused, also similar to Red Team or CTF exercise.
* "Learn about rootkit and remote access" -- high overlap with "Learn about malware, ransomware and recent threats", rootkits are also less of a concern now with secure boot.
* "Learn about data minimalism" -- I think this is referring to "data minimization" but that's covered by local security/privacy laws. As a privacy topic it's also not very deep or actionable.
* "Check if email addresses use TLS before emailing" -- This is nice to know, but unactionable if you need to email someone.
* "Learn about ISO 27001" -- The NIST CSF frameworks are similar, but don't an associated cost because they're published by the US Government so they're more "maker" friendly.
* "Set up an email spam filter" -- Too vague.
* "Learn about X.509 certificates" -- Merged into "Learn about PKI..."
* "Learn about cryptography" -- Too vague, high overlap with practicals of GPG, X.509, and using TLS
* "Submit a bug report" -- Too general.

```
